### PR TITLE
Fix tasks.get_summary() to return backlog list

### DIFF
--- a/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/python_modules/tasks.py
+++ b/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/python_modules/tasks.py
@@ -983,21 +983,36 @@ class Tasks:
         """Get task statistics summary.
         
         Returns:
-            Dictionary with task counts and summaries
+            Dictionary with task counts, summaries, and backlog
             
         Example:
             summary = tasks.get_summary()
             print(f"Active: {summary['active_count']}")
+            print(f"Backlog tasks: {len(summary['backlog'])}")
         """
         # Get all non-completed tasks
-        active = [t for t in self.get_all() if t.get('status') != 'completed']
+        all_tasks = self.get_all()
+        active = [t for t in all_tasks if t.get('status') != 'completed']
         blocked = self.get_blocked()
         completed = self.get_completed(5)
+        
+        # Build backlog (all non-completed, non-blocked tasks)
+        backlog = []
+        for task in all_tasks:
+            if task.get('status') not in ['completed', 'blocked']:
+                backlog.append({
+                    'id': task['id'],
+                    'summary': task['summary'],
+                    'type': task.get('task_type', 'unknown'),
+                    'current': task.get('current', False)
+                })
         
         return {
             "active_count": len(active),
             "blocked_count": len(blocked),
             "completed_recent": len(completed),
             "active_summaries": [t['summary'] for t in active],
-            "blocked_summaries": [t['summary'] for t in blocked]
+            "blocked_summaries": [t['summary'] for t in blocked],
+            "backlog": backlog,  # Added backlog list
+            "current_task": next((t for t in backlog if t.get('current')), None)
         }


### PR DESCRIPTION
## Summary
- Fixed `tasks.get_summary()` to return a 'backlog' key with available tasks
- Added 'current_task' key to identify the active task

## Problem
Alice couldn't set maintenance tasks because her script was reasonably checking if tasks existed in the backlog before attempting to set them. The `get_summary()` method wasn't returning this expected information.

## Solution  
Enhanced `get_summary()` to return:
- `backlog`: List of all non-completed, non-blocked tasks with their IDs and summaries
- `current_task`: The currently active task from the backlog (if any)

## Why This Fix Makes Sense
When a cyber calls `tasks.get_summary()`, they reasonably expect to get a summary that includes what tasks are available. Alice's code was correct in its assumptions - the API was incomplete.

🤖 Generated with [Claude Code](https://claude.ai/code)