### PR TITLE
Typed WS event envelopes, OpenAPI export, dual-repo dev tooling

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -1,0 +1,31 @@
+name: OpenAPI Schema Check
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  export-and-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Export OpenAPI
+        run: |
+          python scripts/export_openapi.py --out docs/openapi.json
+
+      - name: Verify schema is committed
+        run: |
+          git diff --exit-code -- docs/openapi.json

--- a/docs/dev-multi-repo.md
+++ b/docs/dev-multi-repo.md
@@ -1,0 +1,42 @@
+**Dual‑Repo Dev (Server + Client)**
+
+- Repos:
+  - Server: this repo (FastAPI on `MIND_SWARM_PORT`, default `8888`).
+  - Client: `mind-swarm-3d-monitor` (TypeScript/3D monitor UI).
+
+- Run both locally:
+  - Copy `.env.example` to `.env` and set `MIND_SWARM_PORT` if needed.
+  - Start both with: `bash scripts/dev.sh`
+    - Defaults assume sibling repos:
+      - Server: `~/projects/mind-swarm-work`
+      - Client: `~/projects/mind-swarm-3d-monitor`
+    - Exports `API_BASE_URL` (configurable) to the client process.
+
+- Overrides:
+  - `CLIENT_DIR=~/projects/mind-swarm-3d-monitor` to point to your client checkout.
+  - `CLIENT_CMD="npm run dev"` for your client dev command.
+  - `CLIENT_API_ENV_VAR=API_BASE_URL` if the client expects a different env var name.
+  - `MIND_SWARM_PORT=8888` to match the server port.
+
+- Example:
+  - `CLIENT_DIR=~/projects/mind-swarm-3d-monitor CLIENT_CMD="npm run dev" bash scripts/dev.sh`
+
+- CORS: server allows all origins in dev (`CORSMiddleware`), so no extra setup needed.
+
+- API Contract:
+  - FastAPI exposes `/openapi.json` and interactive docs at `/docs` when the server is running.
+  - Recommended: generate client types from OpenAPI in the client repo (e.g., `openapi-typescript`).
+  - CI tip: add a contract check that diffs the generated types or schema to catch drift.
+  - Offline schema: export with `python scripts/export_openapi.py --out docs/openapi.json` and point the client generator at that file.
+
+- WebSocket Events:
+  - The server now emits typed envelopes for WS messages under `src/mind_swarm/server/schemas/events.py`.
+  - Envelope shape: `{ type: string, data: object, timestamp: string }`.
+  - Existing ad-hoc events are still supported for backward compatibility, but new events follow the envelope.
+  - Client suggestion: create `src/ws/events.ts` with a union of event types and optional Zod validators to validate `data` per event.
+  - Migration path: prefer using `data` payloads in the client; keep a fallback for legacy top-level fields.
+  - Subscriptions: client sends `{ type: "subscribe", cybers: ["*"] }` on connect by default; adjust with `WebSocketClient.subscribe(["Alice"])`.
+
+- Notes:
+  - `scripts/dev.sh` starts the server via `./run.sh server --debug --llm-debug`, waits for readiness, and then runs the client in the foreground. Exiting the client stops the server.
+  - If your client requires a different env var (e.g., `VITE_API_BASE_URL`), set `CLIENT_API_ENV_VAR` accordingly.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,37 @@
+**WebSocket Events**
+
+- Envelope: `{ type: string, data: object, timestamp: string }`
+- Purpose: Consistent, typed events for the 3D monitor client.
+
+- Core Types:
+  - `agent_created`: `{ name }`
+  - `agent_terminated`: `{ name }`
+  - `agent_state_changed`: `{ name, old_state, new_state }`
+  - `agent_thinking`: `{ name, thought, token_count? }`
+  - `question_created`: `{ question_id, text, created_by }`
+  - `task_created`: `{ task_id, summary, created_by }`
+  - `announcement_updated`: `{ title, message, priority }`
+  - `announcements_cleared`: `{}`
+  - `developer_registered`: `{ name, cyber_name }`
+  - `token_boost_applied`: `{ cyber_id, multiplier, duration_hours }`
+  - `token_boost_cleared`: `{ cyber_id }`
+  - `cyber_restarted`: `{ name }`
+  - `cyber_paused`: `{ name }`
+  - `system_metrics`: object
+  - `cycle_started`: `{ cyber, cycle_number }`
+  - `cycle_completed`: `{ cyber, cycle_number, duration_ms }`
+  - `stage_started`: `{ cyber, cycle_number, stage }`
+  - `stage_completed`: `{ cyber, cycle_number, stage, stage_data? }`
+  - `memory_changed`: `{ cyber, cycle_number, operation, memory_info }`
+  - `message_sent`: `{ from, to, subject }`
+  - `message_activity`: `{ from, to, from_cycle, message_type, content }`
+  - `brain_thinking`: `{ cyber, cycle_number, stage, request, response? }`
+  - `file_activity`: `{ cyber, action, path }`
+  - `file_operation`: `{ cyber, cycle_number, operation, path, details? }`
+  - `token_usage`: `{ cyber, cycle_number, stage, tokens }`
+  - Heartbeat: `ping` events are periodically emitted by server; client may send `{ type: "ping" }` and receive `pong` in response.
+
+- Source Files:
+  - Server models: `src/mind_swarm/server/schemas/events.py`
+  - Server emitter: `src/mind_swarm/server/monitoring_events.py`
+  - Client types: `mind-swarm-3d-monitor/src/ws/events.ts`

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1833 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Mind-Swarm Server",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "summary": "Root",
+        "description": "Root endpoint.",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Get Status",
+        "description": "Get server and Cyber status.\n\nArgs:\n    check_llm: Whether to check local LLM status (can be slow)",
+        "operationId": "get_status_status_get",
+        "parameters": [
+          {
+            "name": "check_llm",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Check Llm"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/create": {
+      "post": {
+        "summary": "Create Agent",
+        "description": "Create a new Cyber.",
+        "operationId": "create_agent_Cybers_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{name}": {
+      "delete": {
+        "summary": "Terminate Agent",
+        "description": "Terminate an Cyber.",
+        "operationId": "terminate_agent_Cybers__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{name}/command": {
+      "post": {
+        "summary": "Send Command",
+        "description": "Send a command to an Cyber.",
+        "operationId": "send_command_Cybers__name__command_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommandRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{name}/message": {
+      "post": {
+        "summary": "Send Message",
+        "description": "Send a message to an Cyber.",
+        "operationId": "send_message_Cybers__name__message_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MessageRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/community/questions": {
+      "get": {
+        "summary": "Get Questions",
+        "description": "Get all community questions.",
+        "operationId": "get_questions_community_questions_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Question",
+        "description": "Create a new community question.",
+        "operationId": "create_question_community_questions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/community/tasks": {
+      "get": {
+        "summary": "Get Tasks",
+        "description": "Get all community tasks.",
+        "operationId": "get_tasks_community_tasks_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create Task",
+        "description": "Create a new community task.",
+        "operationId": "create_task_community_tasks_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/community/announcements": {
+      "post": {
+        "summary": "Update Announcements",
+        "description": "Update system announcements for all Cybers.",
+        "operationId": "update_announcements_community_announcements_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnouncementRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Clear Announcements",
+        "description": "Clear all system announcements.",
+        "operationId": "clear_announcements_community_announcements_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/all": {
+      "get": {
+        "summary": "List All Agents",
+        "description": "List all known Cybers including hibernating ones.",
+        "operationId": "list_all_agents_Cybers_all_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/{cyber_id}/terminals": {
+      "post": {
+        "summary": "Create Terminal",
+        "description": "Create a new terminal session for a Cyber.",
+        "operationId": "create_terminal_cybers__cyber_id__terminals_post",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TerminalCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List Terminals",
+        "description": "List all terminal sessions for a Cyber.",
+        "operationId": "list_terminals_cybers__cyber_id__terminals_get",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/{cyber_id}/terminals/{session_id}/input": {
+      "post": {
+        "summary": "Send Terminal Input",
+        "description": "Send input to a terminal session.",
+        "operationId": "send_terminal_input_cybers__cyber_id__terminals__session_id__input_post",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TerminalInputRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/{cyber_id}/terminals/{session_id}/screen": {
+      "get": {
+        "summary": "Read Terminal Screen",
+        "description": "Read current screen content from a terminal.",
+        "operationId": "read_terminal_screen_cybers__cyber_id__terminals__session_id__screen_get",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "text",
+              "title": "Format"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/{cyber_id}/terminals/{session_id}": {
+      "delete": {
+        "summary": "Close Terminal",
+        "description": "Close a terminal session.",
+        "operationId": "close_terminal_cybers__cyber_id__terminals__session_id__delete",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/developers/register": {
+      "post": {
+        "summary": "Register Developer",
+        "description": "Register a new developer.",
+        "operationId": "register_developer_developers_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterDeveloperRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/developers/current": {
+      "get": {
+        "summary": "Get Current Developer",
+        "description": "Get the current developer.",
+        "operationId": "get_current_developer_developers_current_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Set Current Developer",
+        "description": "Set the current developer.",
+        "operationId": "set_current_developer_developers_current_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetCurrentDeveloperRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/developers": {
+      "get": {
+        "summary": "List Developers",
+        "description": "List all registered developers.",
+        "operationId": "list_developers_developers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/developers/mailbox": {
+      "get": {
+        "summary": "Check Mailbox",
+        "description": "Check current developer's mailbox.",
+        "operationId": "check_mailbox_developers_mailbox_get",
+        "parameters": [
+          {
+            "name": "include_read",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Read"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/developers/mailbox/read": {
+      "post": {
+        "summary": "Mark Message Read",
+        "description": "Mark a message as read.",
+        "operationId": "mark_message_read_developers_mailbox_read_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkMessageReadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/filesystem/structure": {
+      "get": {
+        "summary": "Get Filesystem Structure",
+        "description": "Get the subspace filesystem structure.",
+        "operationId": "get_filesystem_structure_filesystem_structure_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/search": {
+      "get": {
+        "summary": "Search Knowledge",
+        "description": "Search the knowledge system.",
+        "operationId": "search_knowledge_knowledge_search_get",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Query"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/add": {
+      "post": {
+        "summary": "Add Knowledge",
+        "description": "Add knowledge to the shared system.",
+        "operationId": "add_knowledge_knowledge_add_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/list": {
+      "get": {
+        "summary": "List Knowledge",
+        "description": "List all shared knowledge.",
+        "operationId": "list_knowledge_knowledge_list_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/{knowledge_id}": {
+      "delete": {
+        "summary": "Remove Knowledge",
+        "description": "Remove knowledge from the system.",
+        "operationId": "remove_knowledge_knowledge__knowledge_id__delete",
+        "parameters": [
+          {
+            "name": "knowledge_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Knowledge Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/stats": {
+      "get": {
+        "summary": "Get Knowledge Stats",
+        "description": "Get knowledge system statistics.",
+        "operationId": "get_knowledge_stats_knowledge_stats_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/knowledge/sync": {
+      "post": {
+        "summary": "Sync Knowledge",
+        "description": "Sync knowledge from initial_knowledge templates to ChromaDB.",
+        "operationId": "sync_knowledge_knowledge_sync_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/freeze/{cyber_name}": {
+      "post": {
+        "summary": "Freeze Cyber",
+        "description": "Freeze a single Cyber to a tar.gz archive.",
+        "operationId": "freeze_cyber_cybers_freeze__cyber_name__post",
+        "parameters": [
+          {
+            "name": "cyber_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/freeze-all": {
+      "post": {
+        "summary": "Freeze All Cybers",
+        "description": "Freeze all Cybers to a single tar.gz archive.",
+        "operationId": "freeze_all_cybers_cybers_freeze_all_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/unfreeze": {
+      "post": {
+        "summary": "Unfreeze Cybers",
+        "description": "Unfreeze Cybers from a tar.gz archive.",
+        "operationId": "unfreeze_cybers_cybers_unfreeze_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnfreezeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cybers/frozen": {
+      "get": {
+        "summary": "List Frozen Cybers",
+        "description": "List all frozen Cyber archives.",
+        "operationId": "list_frozen_cybers_cybers_frozen_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Get System Metrics",
+        "description": "Get system metrics for developer mode.",
+        "operationId": "get_system_metrics_metrics_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/token/boost": {
+      "post": {
+        "summary": "Apply Token Boost",
+        "description": "Apply a temporary token rate boost to cybers.",
+        "operationId": "apply_token_boost_token_boost_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenBoostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Clear Token Boost",
+        "description": "Clear token boost for a cyber or all cybers.",
+        "operationId": "clear_token_boost_token_boost_delete",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cyber Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Get Token Boost Status",
+        "description": "Get current token boost status.",
+        "operationId": "get_token_boost_status_token_boost_get",
+        "parameters": [
+          {
+            "name": "cyber_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cyber Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{cyber_name}/inspect": {
+      "get": {
+        "summary": "Inspect Cyber",
+        "description": "Get detailed inspection data for a specific Cyber.",
+        "operationId": "inspect_cyber_Cybers__cyber_name__inspect_get",
+        "parameters": [
+          {
+            "name": "cyber_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{cyber_name}/restart": {
+      "post": {
+        "summary": "Restart Cyber",
+        "description": "Restart a specific Cyber.",
+        "operationId": "restart_cyber_Cybers__cyber_name__restart_post",
+        "parameters": [
+          {
+            "name": "cyber_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/Cybers/{cyber_name}/pause": {
+      "post": {
+        "summary": "Pause Cyber",
+        "description": "Pause a specific Cyber.",
+        "operationId": "pause_cyber_Cybers__cyber_name__pause_post",
+        "parameters": [
+          {
+            "name": "cyber_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Cyber Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AnnouncementRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "priority": {
+            "type": "string",
+            "title": "Priority",
+            "default": "HIGH"
+          },
+          "expires": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "message"
+        ],
+        "title": "AnnouncementRequest",
+        "description": "Request to create or update system announcements."
+      },
+      "CommandRequest": {
+        "properties": {
+          "command": {
+            "type": "string",
+            "title": "Command"
+          },
+          "params": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Params"
+          }
+        },
+        "type": "object",
+        "required": [
+          "command"
+        ],
+        "title": "CommandRequest",
+        "description": "Request to send a command to an Cyber."
+      },
+      "CreateAgentRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "cyber_type": {
+            "type": "string",
+            "title": "Cyber Type",
+            "default": "general"
+          },
+          "config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Config"
+          }
+        },
+        "type": "object",
+        "title": "CreateAgentRequest",
+        "description": "Request to create a new Cyber."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "MarkMessageReadRequest": {
+        "properties": {
+          "message_index": {
+            "type": "integer",
+            "title": "Message Index"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message_index"
+        ],
+        "title": "MarkMessageReadRequest",
+        "description": "Request model for marking message as read."
+      },
+      "MessageRequest": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "subject": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subject"
+          }
+        },
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "MessageRequest",
+        "description": "Request to send a message to an Cyber."
+      },
+      "QuestionRequest": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By",
+            "default": "user"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "QuestionRequest",
+        "description": "Request to create a community question."
+      },
+      "RegisterDeveloperRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "RegisterDeveloperRequest",
+        "description": "Request model for registering a developer."
+      },
+      "SetCurrentDeveloperRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "SetCurrentDeveloperRequest",
+        "description": "Request model for setting current developer."
+      },
+      "StatusResponse": {
+        "properties": {
+          "Cybers": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Cybers"
+          },
+          "community_questions": {
+            "type": "integer",
+            "title": "Community Questions"
+          },
+          "server_uptime": {
+            "type": "number",
+            "title": "Server Uptime"
+          },
+          "server_start_time": {
+            "type": "string",
+            "title": "Server Start Time"
+          },
+          "token_usage": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token Usage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "Cybers",
+          "community_questions",
+          "server_uptime",
+          "server_start_time"
+        ],
+        "title": "StatusResponse",
+        "description": "Server status response."
+      },
+      "TaskRequest": {
+        "properties": {
+          "summary": {
+            "type": "string",
+            "title": "Summary"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "priority": {
+            "type": "string",
+            "title": "Priority",
+            "default": "normal"
+          },
+          "category": {
+            "type": "string",
+            "title": "Category",
+            "default": "general"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By",
+            "default": "user"
+          }
+        },
+        "type": "object",
+        "required": [
+          "summary",
+          "description"
+        ],
+        "title": "TaskRequest",
+        "description": "Request to create a community task."
+      },
+      "TerminalCreateRequest": {
+        "properties": {
+          "command": {
+            "type": "string",
+            "title": "Command",
+            "default": "bash"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "TerminalCreateRequest",
+        "description": "Request to create a terminal session."
+      },
+      "TerminalInputRequest": {
+        "properties": {
+          "input": {
+            "type": "string",
+            "title": "Input"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input"
+        ],
+        "title": "TerminalInputRequest",
+        "description": "Request to send input to a terminal."
+      },
+      "TokenBoostRequest": {
+        "properties": {
+          "cyber_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cyber Id"
+          },
+          "multiplier": {
+            "type": "number",
+            "title": "Multiplier",
+            "default": 2.0
+          },
+          "duration_hours": {
+            "type": "number",
+            "title": "Duration Hours",
+            "default": 3.0
+          }
+        },
+        "type": "object",
+        "title": "TokenBoostRequest",
+        "description": "Request model for applying token boost."
+      },
+      "UnfreezeRequest": {
+        "properties": {
+          "archive_path": {
+            "type": "string",
+            "title": "Archive Path"
+          },
+          "force": {
+            "type": "boolean",
+            "title": "Force",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "archive_path"
+        ],
+        "title": "UnfreezeRequest",
+        "description": "Request to unfreeze Cybers from an archive."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Orchestrate server + client (mind-swarm-3d-monitor) during development.
+#
+# Defaults assume sibling repos:
+#   - this repo:   ~/projects/mind-swarm-work
+#   - client repo: ~/projects/mind-swarm-3d-monitor
+#
+# Env overrides:
+#   CLIENT_DIR             Path to client repo (default: ../mind-swarm-3d-monitor)
+#   CLIENT_CMD             Command to start client (default: npm run dev)
+#   CLIENT_API_ENV_VAR     Env var name used by client for API URL (default: API_BASE_URL)
+#   MIND_SWARM_PORT        Server port (default: 8888)
+#   SERVER_ARGS            Extra args for server (e.g., "--debug --llm-debug")
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+# Config
+CLIENT_DIR=${CLIENT_DIR:-"$root/../mind-swarm-3d-monitor"}
+CLIENT_CMD=${CLIENT_CMD:-"npm run dev"}
+CLIENT_API_ENV_VAR=${CLIENT_API_ENV_VAR:-"API_BASE_URL"}
+PORT=${MIND_SWARM_PORT:-8888}
+SERVER_ARGS=${SERVER_ARGS:-"--debug --llm-debug"}
+
+log() { echo -e "\033[0;36m[dev]\033[0m $*"; }
+err() { echo -e "\033[0;31m[dev]\033[0m $*" 1>&2; }
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    err "Missing dependency: $1"
+    exit 1
+  fi
+}
+
+require bash
+require grep
+
+# Start server (daemonized by run.sh) and wait for readiness
+start_server() {
+  log "Starting server on port $PORT..."
+  pushd "$root" >/dev/null
+  MIND_SWARM_PORT="$PORT" ./run.sh server $SERVER_ARGS || true
+  popd >/dev/null
+
+  # Wait for /status to become available
+  if command -v curl >/dev/null 2>&1; then
+    log "Waiting for server readiness at http://localhost:$PORT/status ..."
+    for i in {1..60}; do
+      if curl -fsS "http://localhost:$PORT/status" >/dev/null 2>&1; then
+        log "Server is ready."
+        return 0
+      fi
+      sleep 0.5
+    done
+    err "Server did not become ready in time. Check ./run.sh logs"
+  else
+    log "curl not found; skipping readiness check."
+  fi
+}
+
+stop_server() {
+  log "Stopping server..."
+  pushd "$root" >/dev/null
+  ./run.sh stop || true
+  popd >/dev/null
+}
+
+start_client() {
+  if [ ! -d "$CLIENT_DIR" ]; then
+    err "Client directory not found: $CLIENT_DIR"
+    err "Set CLIENT_DIR to your client repo path."
+    exit 1
+  fi
+
+  log "Starting client in $CLIENT_DIR"
+  pushd "$CLIENT_DIR" >/dev/null
+
+  # Export API base URL for the client process
+  export "$CLIENT_API_ENV_VAR"="http://localhost:$PORT"
+  log "Exported $CLIENT_API_ENV_VAR=$API_BASE_URL"
+
+  # Run client in foreground so Ctrl-C stops it
+  set +e
+  bash -lc "$CLIENT_CMD"
+  client_exit=$?
+  set -e
+  popd >/dev/null
+  return $client_exit
+}
+
+cleanup() {
+  log "Cleaning up..."
+  stop_server
+}
+
+trap cleanup EXIT INT TERM
+
+start_server
+start_client
+
+exit $?
+

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Export the FastAPI OpenAPI schema to a JSON file.
+
+Usage:
+  python scripts/export_openapi.py [--out docs/openapi.json]
+
+This does not start the server; it instantiates the app and dumps its schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from mind_swarm.server.api import MindSwarmServer
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export OpenAPI schema")
+    parser.add_argument(
+        "--out",
+        default="docs/openapi.json",
+        help="Output file path (default: docs/openapi.json)",
+    )
+    args = parser.parse_args()
+
+    server = MindSwarmServer()
+    schema = server.app.openapi()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(schema, indent=2))
+    print(f"Wrote OpenAPI schema to {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/mind_swarm/server/monitoring_events.py
+++ b/src/mind_swarm/server/monitoring_events.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional, List
 from datetime import datetime
 
 from mind_swarm.utils.logging import logger
+from mind_swarm.server.schemas.events import make_event
 
 
 class MonitoringEventEmitter:
@@ -26,15 +27,15 @@ class MonitoringEventEmitter:
         if not self.server:
             return
             
-        await self.server._broadcast_event({
-            "type": "agent_state_changed",
-            "data": {
+        event = make_event(
+            "agent_state_changed",
+            {
                 "name": cyber_name,
                 "old_state": old_state,
-                "new_state": new_state
+                "new_state": new_state,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted agent_state_changed: {cyber_name} {old_state} -> {new_state}")
         
     async def emit_agent_thinking(self, cyber_name: str, thought: str, token_count: Optional[int] = None):
@@ -44,31 +45,23 @@ class MonitoringEventEmitter:
             
         data = {
             "name": cyber_name,
-            "thought": thought[:200] + "..." if len(thought) > 200 else thought  # Truncate long thoughts
+            "thought": thought[:200] + "..." if len(thought) > 200 else thought,
         }
         if token_count is not None:
             data["token_count"] = token_count
-            
-        await self.server._broadcast_event({
-            "type": "agent_thinking",
-            "data": data,
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event("agent_thinking", data)
+        await self.server._broadcast_event(event)
         
     async def emit_message_sent(self, from_agent: str, to_agent: str, subject: str):
         """Emit a message sent event."""
         if not self.server:
             return
             
-        await self.server._broadcast_event({
-            "type": "message_sent",
-            "data": {
-                "from": from_agent,
-                "to": to_agent,
-                "subject": subject
-            },
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event(
+            "message_sent",
+            {"from": from_agent, "to": to_agent, "subject": subject},
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted message_sent: {from_agent} -> {to_agent}: {subject}")
         
     async def emit_file_activity(self, cyber_name: str, action: str, path: str):
@@ -76,26 +69,19 @@ class MonitoringEventEmitter:
         if not self.server:
             return
             
-        await self.server._broadcast_event({
-            "type": "file_activity",
-            "data": {
-                "cyber": cyber_name,
-                "action": action,  # read, write, create, delete
-                "path": path
-            },
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event(
+            "file_activity",
+            {"cyber": cyber_name, "action": action, "path": path},
+        )
+        await self.server._broadcast_event(event)
         
     async def emit_system_metrics(self, metrics: Dict[str, Any]):
         """Emit system metrics update."""
         if not self.server:
             return
             
-        await self.server._broadcast_event({
-            "type": "system_metrics",
-            "data": metrics,
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event("system_metrics", metrics)
+        await self.server._broadcast_event(event)
     
     async def emit_cycle_started(self, cyber_name: str, cycle_number: int):
         """Emit cycle started event."""
@@ -104,14 +90,11 @@ class MonitoringEventEmitter:
         
         self.cyber_cycles[cyber_name] = cycle_number
         
-        await self.server._broadcast_event({
-            "type": "cycle_started",
-            "data": {
-                "cyber": cyber_name,
-                "cycle_number": cycle_number
-            },
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event(
+            "cycle_started",
+            {"cyber": cyber_name, "cycle_number": cycle_number},
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted cycle_started: {cyber_name} cycle {cycle_number}")
     
     async def emit_cycle_completed(self, cyber_name: str, cycle_number: int, duration_ms: int):
@@ -119,15 +102,15 @@ class MonitoringEventEmitter:
         if not self.server:
             return
         
-        await self.server._broadcast_event({
-            "type": "cycle_completed",
-            "data": {
+        event = make_event(
+            "cycle_completed",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
-                "duration_ms": duration_ms
+                "duration_ms": duration_ms,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted cycle_completed: {cyber_name} cycle {cycle_number}")
     
     async def emit_stage_started(self, cyber_name: str, cycle_number: int, stage: str):
@@ -135,15 +118,11 @@ class MonitoringEventEmitter:
         if not self.server:
             return
         
-        await self.server._broadcast_event({
-            "type": "stage_started",
-            "data": {
-                "cyber": cyber_name,
-                "cycle_number": cycle_number,
-                "stage": stage
-            },
-            "timestamp": datetime.now().isoformat()
-        })
+        event = make_event(
+            "stage_started",
+            {"cyber": cyber_name, "cycle_number": cycle_number, "stage": stage},
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted stage_started: {cyber_name} cycle {cycle_number} stage {stage}")
     
     async def emit_stage_completed(self, cyber_name: str, cycle_number: int, stage: str, 
@@ -152,16 +131,16 @@ class MonitoringEventEmitter:
         if not self.server:
             return
         
-        await self.server._broadcast_event({
-            "type": "stage_completed",
-            "data": {
+        event = make_event(
+            "stage_completed",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
                 "stage": stage,
-                "stage_data": stage_data or {}
+                "stage_data": stage_data or {},
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted stage_completed: {cyber_name} cycle {cycle_number} stage {stage}")
     
     async def emit_memory_changed(self, cyber_name: str, operation: str, memory_info: Dict[str, Any]):
@@ -171,16 +150,16 @@ class MonitoringEventEmitter:
         
         cycle_number = self.cyber_cycles.get(cyber_name, 0)
         
-        await self.server._broadcast_event({
-            "type": "memory_changed",
-            "data": {
+        event = make_event(
+            "memory_changed",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
-                "operation": operation,  # add, remove, update
-                "memory_info": memory_info
+                "operation": operation,
+                "memory_info": memory_info,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
     
     async def emit_message_activity(self, from_cyber: str, to_cyber: str, 
                                    message_type: str, content: Dict[str, Any]):
@@ -190,17 +169,17 @@ class MonitoringEventEmitter:
         
         from_cycle = self.cyber_cycles.get(from_cyber, 0)
         
-        await self.server._broadcast_event({
-            "type": "message_activity",
-            "data": {
+        event = make_event(
+            "message_activity",
+            {
                 "from": from_cyber,
                 "to": to_cyber,
                 "from_cycle": from_cycle,
                 "message_type": message_type,
-                "content": content
+                "content": content,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
         logger.debug(f"Emitted message_activity: {from_cyber} -> {to_cyber}")
     
     async def emit_brain_thinking(self, cyber_name: str, stage: str, 
@@ -211,17 +190,17 @@ class MonitoringEventEmitter:
         
         cycle_number = self.cyber_cycles.get(cyber_name, 0)
         
-        await self.server._broadcast_event({
-            "type": "brain_thinking",
-            "data": {
+        event = make_event(
+            "brain_thinking",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
                 "stage": stage,
                 "request": request,
-                "response": response
+                "response": response,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
     
     async def emit_file_operation(self, cyber_name: str, operation: str, 
                                  path: str, details: Optional[Dict[str, Any]] = None):
@@ -231,17 +210,17 @@ class MonitoringEventEmitter:
         
         cycle_number = self.cyber_cycles.get(cyber_name, 0)
         
-        await self.server._broadcast_event({
-            "type": "file_operation",
-            "data": {
+        event = make_event(
+            "file_operation",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
-                "operation": operation,  # read, write, create, delete
+                "operation": operation,
                 "path": path,
-                "details": details or {}
+                "details": details or {},
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
     
     async def emit_token_usage(self, cyber_name: str, stage: str, tokens: Dict[str, int]):
         """Emit token usage statistics."""
@@ -250,16 +229,16 @@ class MonitoringEventEmitter:
         
         cycle_number = self.cyber_cycles.get(cyber_name, 0)
         
-        await self.server._broadcast_event({
-            "type": "token_usage",
-            "data": {
+        event = make_event(
+            "token_usage",
+            {
                 "cyber": cyber_name,
                 "cycle_number": cycle_number,
                 "stage": stage,
-                "tokens": tokens
+                "tokens": tokens,
             },
-            "timestamp": datetime.now().isoformat()
-        })
+        )
+        await self.server._broadcast_event(event)
 
 
 # Global event emitter instance

--- a/src/mind_swarm/server/schemas/events.py
+++ b/src/mind_swarm/server/schemas/events.py
@@ -1,0 +1,128 @@
+"""Typed WebSocket event schemas for the Mind-Swarm server.
+
+These Pydantic models define the shapes of messages sent over the `/ws`
+WebSocket endpoint. They use a uniform envelope with:
+
+- type: literal event name
+- data: typed payload
+- timestamp: ISO timestamp string
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any, Optional, Literal
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class EventBase(BaseModel):
+    """Base event envelope."""
+
+    type: str
+    data: Dict[str, Any] = Field(default_factory=dict)
+    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat())
+
+
+# Individual event types -----------------------------------------------------
+
+
+class AgentStateChanged(EventBase):
+    type: Literal["agent_state_changed"] = "agent_state_changed"
+    data: Dict[str, Any]
+
+
+class AgentThinking(EventBase):
+    type: Literal["agent_thinking"] = "agent_thinking"
+    data: Dict[str, Any]
+
+
+class MessageSent(EventBase):
+    type: Literal["message_sent"] = "message_sent"
+    data: Dict[str, Any]
+
+
+class FileActivity(EventBase):
+    type: Literal["file_activity"] = "file_activity"
+    data: Dict[str, Any]
+
+
+class SystemMetrics(EventBase):
+    type: Literal["system_metrics"] = "system_metrics"
+    data: Dict[str, Any]
+
+
+class CycleStarted(EventBase):
+    type: Literal["cycle_started"] = "cycle_started"
+    data: Dict[str, Any]
+
+
+class CycleCompleted(EventBase):
+    type: Literal["cycle_completed"] = "cycle_completed"
+    data: Dict[str, Any]
+
+
+class StageStarted(EventBase):
+    type: Literal["stage_started"] = "stage_started"
+    data: Dict[str, Any]
+
+
+class StageCompleted(EventBase):
+    type: Literal["stage_completed"] = "stage_completed"
+    data: Dict[str, Any]
+
+
+class MemoryChanged(EventBase):
+    type: Literal["memory_changed"] = "memory_changed"
+    data: Dict[str, Any]
+
+
+class MessageActivity(EventBase):
+    type: Literal["message_activity"] = "message_activity"
+    data: Dict[str, Any]
+
+
+class BrainThinking(EventBase):
+    type: Literal["brain_thinking"] = "brain_thinking"
+    data: Dict[str, Any]
+
+
+class FileOperation(EventBase):
+    type: Literal["file_operation"] = "file_operation"
+    data: Dict[str, Any]
+
+
+class TokenUsage(EventBase):
+    type: Literal["token_usage"] = "token_usage"
+    data: Dict[str, Any]
+
+
+# Utility factory helpers ----------------------------------------------------
+
+
+def make_event(event_type: str, data: Dict[str, Any]) -> EventBase:
+    """Factory that returns a typed event model when known, else generic envelope.
+
+    Keeps backward compatibility while encouraging typed events.
+    """
+    mapping = {
+        "agent_state_changed": AgentStateChanged,
+        "agent_thinking": AgentThinking,
+        "message_sent": MessageSent,
+        "file_activity": FileActivity,
+        "system_metrics": SystemMetrics,
+        "cycle_started": CycleStarted,
+        "cycle_completed": CycleCompleted,
+        "stage_started": StageStarted,
+        "stage_completed": StageCompleted,
+        "memory_changed": MemoryChanged,
+        "message_activity": MessageActivity,
+        "brain_thinking": BrainThinking,
+        "file_operation": FileOperation,
+        "token_usage": TokenUsage,
+    }
+    model = mapping.get(event_type)
+    if model:
+        return model(data=data)
+    return EventBase(type=event_type, data=data)
+


### PR DESCRIPTION
Summary
- Add typed WebSocket event envelopes and broadcaster normalization
- Convert monitoring + ad-hoc events to envelopes (backwards compatible)
- Add scripts/export_openapi.py and commit docs/openapi.json
- Add scripts/dev.sh for dual-repo dev; update docs
- Add OpenAPI schema check CI workflow

Client PR: https://github.com/ltngt-ai/mind-swarm-3d-monitor/pull/1

How to test
- Run: bash scripts/dev.sh (starts server + waits)
- Open the 3D monitor; observe typed WS flow
- Schema: docs/openapi.json; client can generate types from it
