### PR TITLE
Define path-based ID scheme for knowledge and CBR (vibe-kanban)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ OPENAI_API_KEY=your-openai-api-key-here
 ANTHROPIC_API_KEY=your-anthropic-api-key-here
 
 # Subspace Configuration
-SUBSPACE_ROOT=/home/user/mind-swarm/subspace
+# Use a writable local path for your subspace. Tilde is supported.
+SUBSPACE_ROOT=~/projects/subspace
 MAX_AGENTS=5
 AGENT_MEMORY_LIMIT_MB=512
 AGENT_CPU_LIMIT_PERCENT=20

--- a/docs/knowledge_id_policy.md
+++ b/docs/knowledge_id_policy.md
@@ -1,0 +1,117 @@
+# Knowledge and CBR ID Policy
+
+Purpose: define a deterministic, path-based ID scheme for Knowledge and Case‑Based Reasoning (CBR) that is human‑meaningful, stable across sync/export, and minimizes collisions.
+
+## Scope
+- Knowledge items persisted in the shared store (e.g., ChromaDB) and synced from templates/library.
+- CBR cases stored in personal or shared CBR collections.
+
+## Core Principles
+- Deterministic: the same source path yields the same ID.
+- Relative: IDs use relative paths (no leading slash), scoped by a top‑level namespace.
+- Normalized: lowercase; trim whitespace; replace spaces with `-`; use forward slashes.
+- Minimal charset: `[a-z0-9-_/]` for path segments. Knowledge items may retain dots in filenames for extensions.
+- Namespaced: avoid cross‑domain collisions and keep intent clear.
+
+## Namespaces and Formats
+- Knowledge
+  - `templates/<rel_path>`: Content synced from `subspace_template/initial_knowledge`.
+  - `library/sections/<rel_path>`: Curated library sections and imports.
+  - `community/<area>/<slug>`: Community‑maintained notes (e.g., prompts, guides).
+  - `personal/<cyber>/<category>/<slug>`: Personal notes/playbooks for a given cyber.
+  - Notes:
+    - Keep file extensions for knowledge paths when they originate from files (e.g., `.md`, `.yml`).
+    - Use forward slashes; no leading slash; lowercase.
+
+- CBR
+  - Optional path‑based case IDs: `cases/<domain>/<topic>/<slug>`.
+  - Otherwise, fall back to generated IDs (current format `cbr_<cyber>_<hash>_<epoch>`).
+  - Case IDs should not include file extensions.
+
+## Normalization Rules
+- Lowercase all segments.
+- Trim around separators; collapse internal whitespace to single hyphens per segment.
+- Remove leading slashes; preserve a single forward slash as separator.
+- Accept only `[a-z0-9-_/]` for CBR case IDs; knowledge IDs may include dots in the final filename when derived from files.
+
+Examples (input → ID)
+- Knowledge
+  - `initial_knowledge/guides/Onboarding.md` → `templates/guides/onboarding.md`
+  - `library/sections/Python/AsyncIO.md` → `library/sections/python/asyncio.md`
+  - `community/Prompts/Summarization` → `community/prompts/summarization`
+  - `personal/Cyber-42/Playbooks/Retry Strategies` → `personal/cyber-42/playbooks/retry-strategies`
+- CBR
+  - `DevOps/Deploy/Rollout Strategy v1` → `cases/devops/deploy/rollout-strategy-v1`
+
+## Current Behavior vs. Target
+- Today, the template sync uses the file path relative to `subspace_template/initial_knowledge` as the knowledge ID. Conceptually, this maps to the `templates/<rel_path>` namespace. Future config will make this explicit in exports and cross‑repo sync.
+- CBR now supports optional path‑based IDs when provided (see API below). If not provided, it continues to generate unique IDs.
+
+## Collision Handling
+- Knowledge
+  - Sync compares by ID. If a matching ID exists, the item is updated; otherwise, it is created.
+  - Avoid duplicate items that differ only by letter case — IDs are treated as lowercase canonical forms.
+  - Prefer meaningful reorganization via content moves (keeping IDs stable) instead of duplicating similar items.
+
+- CBR
+  - If you supply an explicit `case_id` or a `metadata.case_path` that normalizes to an existing ID in either personal or shared collection, the store operation returns an error and does not overwrite.
+  - To update an existing case, use `update_score` or a future explicit update flow. To create variants, append a semantic suffix (e.g., `-v2`, `-2025-09-03`).
+  - If you do not supply a path, the system generates a unique ID; collisions are not expected in that mode.
+
+## API Usage
+- Knowledge
+  - CLI and server already support sync from template files. The ID is the relative file path in the template tree (conceptually `templates/<rel_path>`).
+
+- CBR
+  - Store with an explicit `case_id`:
+    {
+      "operation": "store",
+      "request_id": "req-123",
+      "case_id": "cases/devops/deploy/rollout-strategy-v1",
+      "case": {
+        "problem_context": "...",
+        "solution": "...",
+        "outcome": "...",
+        "metadata": {"shared": false}
+      }
+    }
+
+  - Store with a `metadata.case_path` (normalized automatically):
+    {
+      "operation": "store",
+      "request_id": "req-124",
+      "case": {
+        "problem_context": "...",
+        "solution": "...",
+        "outcome": "...",
+        "metadata": {
+          "case_path": "DevOps/Deploy/Rollout Strategy v1",
+          "shared": true
+        }
+      }
+    }
+
+  - Retrieve:
+    {"operation": "retrieve", "request_id": "req-125", "context": "...", "options": {"limit": 3}}
+
+  - Update score/usage:
+    {"operation": "update_score", "case_id": "cases/devops/deploy/rollout-strategy-v1", "updates": {"increment_usage": true}}
+
+## Reserved Prefixes
+- Knowledge: `templates/`, `library/sections/`, `community/`, `personal/`.
+- CBR: `cases/`.
+
+## Recommendations
+- Keep Knowledge filenames short and descriptive; avoid deep nesting where possible.
+- Use hyphenated slugs for CBR case IDs to encourage reuse and readability.
+- Prefer stable IDs; avoid renaming unless there is a clear taxonomy improvement.
+
+## Notes on Storage Constraints
+- ChromaDB stores IDs as strings; metadata values are sanitized to primitives. Lists are joined or JSON‑serialized where necessary.
+- Maximum ID length is not strictly enforced, but keeping IDs under ~200 characters is recommended for portability.
+
+## Alignment and Future Work
+- Config alignment: `config/knowledge_sync.yaml` will formalize sync scopes that correspond to the namespaces above.
+- Export/import: exporters should preserve these IDs; importers should normalize to the same rules.
+- Body API: explicit IDs are now supported for CBR; future work may add explicit IDs for other body endpoints.
+

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1411,6 +1411,92 @@
           }
         }
       }
+    },
+    "/biofeedback/{name}/current": {
+      "get": {
+        "summary": "Get Biofeedback Current",
+        "description": "Get the latest biofeedback state for a given Cyber.",
+        "operationId": "get_biofeedback_current_biofeedback__name__current_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/biofeedback/{name}/history": {
+      "get": {
+        "summary": "Get Biofeedback History",
+        "description": "Get recent biofeedback history for a Cyber.",
+        "operationId": "get_biofeedback_history_biofeedback__name__history_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "minutes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 15,
+              "title": "Minutes"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/knowledge_inventory_report.md
+++ b/knowledge_inventory_report.md
@@ -1,0 +1,87 @@
+# Mind-Swarm Knowledge Sources Inventory Report
+
+## Summary
+Total knowledge volume identified for migration: ~252KB across 30 files
+Excludes: cybers/*/.internal/memory/**, .env files, transient logs, Python code files
+
+## Knowledge Sources Identified
+
+### 1. subspace_template/initial_knowledge (ALREADY SUPPORTED)
+- **Path**: `subspace_template/initial_knowledge/`
+- **Volume**: 108KB, 15 files
+- **Format**: YAML files
+- **Content**: Core cyber knowledge including:
+  - Guides (quick tips, summarizing, onboarding)
+  - OODA loop stages (observation, decision, execution, reflection, cleanup)
+  - Concepts (cyber basics, LLM usage, cognitive architecture)
+  - Formats (message format, knowledge format guides)
+  - Library guides (fiction collection)
+
+### 2. grid/library/schemas
+- **Path**: `subspace_template/grid/library/schemas/`
+- **Volume**: 16KB, 3 files
+- **Format**: JSON schema definitions
+- **Content**:
+  - `knowledge_format.json` - Schema for knowledge structure
+  - `message_format.json` - Schema for message protocol
+  - `.description.txt` - Directory metadata
+
+### 3. grid/community (Curated Docs Only)
+- **Path**: `subspace_template/grid/community/`
+- **Volume**: 128KB total, 7 curated document files
+- **Formats**: Markdown (.md) and JSON
+- **Content**:
+  - `cyber_directory.json` - Cyber registry
+  - `BULLETIN_BOARD.md` - Community announcements
+  - `announcements/system_announcements.json` - System messages
+  - School/onboarding materials (3 README files)
+  - Suggestions (memory management enhancement proposal)
+
+### 4. grid/library/non-fiction (Documentation Only)
+- **Path**: `subspace_template/grid/library/non-fiction/`
+- **Volume**: ~35KB of documentation (from 29MB total including code)
+- **Format**: Markdown files
+- **Content**:
+  - `mind_swarm_tech/base_code/CLAUDE.md` - Claude integration guide (12KB)
+  - `mind_swarm_tech/base_code/README.md` - Base code overview
+  - `SCRIPT_EXECUTOR_SUMMARY.md` - Script execution documentation (11KB)
+  - Python modules documentation (11KB)
+
+## Special Formats Detected
+
+1. **YAML Knowledge Format**: Structured knowledge in initial_knowledge uses consistent YAML schema with metadata fields (title, type, context, content)
+2. **JSON Schemas**: Formal schema definitions for message and knowledge formats
+3. **JSON Registries**: cyber_directory.json uses structured JSON for cyber metadata
+4. **Markdown Documentation**: Standard markdown with headers, code blocks, and lists
+
+## Excluded from Migration
+
+Per requirements, the following are excluded:
+- `cybers/*/.internal/memory/**` - Transient cyber memories
+- `.env` files - Environment variables and secrets
+- API keys and credentials
+- Log files (*.log)
+- Python source code (*.py files in base_code)
+- Binary/compiled files
+
+## Recommendations
+
+1. **Priority Order**: 
+   - Start with initial_knowledge (already supported)
+   - Then schemas (foundational for validation)
+   - Community curated docs
+   - Non-fiction documentation
+
+2. **ID Scheme Considerations**:
+   - Use path-based IDs to preserve hierarchy
+   - Example: `knowledge:initial:guides:quick_tips`
+   
+3. **Special Handling**:
+   - JSON schemas should be stored as reference documents
+   - YAML files should preserve their structure for context
+   - Markdown can be chunked at header boundaries
+
+## Next Steps
+- Define ID scheme based on path hierarchy
+- Design sync scope for periodic updates
+- Implement loaders for YAML, JSON, and Markdown formats

--- a/src/mind_swarm/subspace/cbr_handler.py
+++ b/src/mind_swarm/subspace/cbr_handler.py
@@ -107,24 +107,60 @@ class CyberCBRHandler:
             }
     
     async def store(self, request: Dict) -> Dict:
-        """Store a new CBR case."""
+        """Store a new CBR case.
+
+        Supports optional deterministic, path-based IDs when provided by caller.
+
+        - If `request["case_id"]` is set, use it verbatim (after sanitization).
+        - Else if `case["metadata"]["case_path"]` is set, normalize it to a
+          path-like ID under the `cases/` namespace.
+        - Else fall back to the existing generated ID scheme.
+
+        If a provided/derived `case_id` already exists, returns an error without
+        overwriting. Callers can update scores via `update_score` or choose a new ID.
+        """
         try:
             case = request.get('case', {})
-            
-            # Generate unique case ID
-            content_str = f"{case.get('problem_context', '')}_{case.get('solution', '')}"
-            content_hash = hashlib.md5(content_str.encode()).hexdigest()[:8]
-            case_id = f"cbr_{self.cyber_id}_{content_hash}_{int(time.time())}"
-            
+
+            # Determine case ID preference order: explicit -> path-based -> generated
+            explicit_case_id = request.get('case_id') or case.get('case_id')
+            metadata = case.get('metadata', {})
+
+            def _norm_case_path(path_value: str) -> str:
+                """Normalize a case_path into a canonical cases/<...> ID."""
+                path = str(path_value).strip().lstrip('/')
+                # Ensure cases/ prefix
+                if not path.startswith('cases/'):
+                    path = f"cases/{path}"
+                # Collapse whitespace and replace spaces with hyphens in each segment
+                parts = [
+                    '-'.join(seg.strip().split())
+                    for seg in path.split('/') if seg.strip() != ''
+                ]
+                norm = '/'.join(parts)
+                # Lowercase for determinism
+                return norm.lower()
+
+            case_path = metadata.get('case_path')
+
+            if explicit_case_id:
+                case_id = _norm_case_path(explicit_case_id) if '/' in explicit_case_id else explicit_case_id
+            elif case_path:
+                case_id = _norm_case_path(case_path)
+            else:
+                # Fallback: Generate unique case ID
+                content_str = f"{case.get('problem_context', '')}_{case.get('solution', '')}"
+                content_hash = hashlib.md5(content_str.encode()).hexdigest()[:8]
+                case_id = f"cbr_{self.cyber_id}_{content_hash}_{int(time.time())}"
+
             # Prepare case document
             case_doc = json.dumps({
                 "problem_context": case.get('problem_context', ''),
                 "solution": case.get('solution', ''),
                 "outcome": case.get('outcome', '')
             })
-            
-            # Prepare metadata
-            metadata = case.get('metadata', {})
+
+            # Prepare metadata (after we may have read case_path above)
             metadata['cyber_id'] = self.cyber_id
             metadata['case_id'] = case_id
             metadata['case_type'] = 'cbr_case'
@@ -150,7 +186,29 @@ class CyberCBRHandler:
             
             # Determine collection (personal by default)
             collection = self.personal_cbr if not sanitized_metadata.get('shared', False) else self.shared_cbr
-            
+
+            # Collision check: if an explicit/path-based ID exists, do not overwrite
+            if explicit_case_id or case_path:
+                try:
+                    # Check both personal and shared to guard against duplicates across scopes
+                    exists_personal = False
+                    exists_shared = False
+                    if self.personal_cbr:
+                        res = self.personal_cbr.get(ids=[case_id])
+                        exists_personal = bool(res and res.get('documents'))
+                    if self.shared_cbr and not exists_personal:
+                        res = self.shared_cbr.get(ids=[case_id])
+                        exists_shared = bool(res and res.get('documents'))
+                    if exists_personal or exists_shared:
+                        return {
+                            "request_id": request.get('request_id'),
+                            "status": "error",
+                            "error": f"Case ID already exists: {case_id}"
+                        }
+                except Exception:
+                    # If collision check fails, proceed to attempt add and surface any error from DB
+                    pass
+
             # Store in ChromaDB
             collection.add(
                 documents=[case_doc],

--- a/src/mind_swarm/subspace/cbr_handler.py
+++ b/src/mind_swarm/subspace/cbr_handler.py
@@ -126,27 +126,15 @@ class CyberCBRHandler:
             explicit_case_id = request.get('case_id') or case.get('case_id')
             metadata = case.get('metadata', {})
 
-            def _norm_case_path(path_value: str) -> str:
-                """Normalize a case_path into a canonical cases/<...> ID."""
-                path = str(path_value).strip().lstrip('/')
-                # Ensure cases/ prefix
-                if not path.startswith('cases/'):
-                    path = f"cases/{path}"
-                # Collapse whitespace and replace spaces with hyphens in each segment
-                parts = [
-                    '-'.join(seg.strip().split())
-                    for seg in path.split('/') if seg.strip() != ''
-                ]
-                norm = '/'.join(parts)
-                # Lowercase for determinism
-                return norm.lower()
+            # Use shared normalizer for deterministic case IDs
+            from mind_swarm.utils.id_policy import normalize_cbr_case_id
 
             case_path = metadata.get('case_path')
 
             if explicit_case_id:
-                case_id = _norm_case_path(explicit_case_id) if '/' in explicit_case_id else explicit_case_id
+                case_id = normalize_cbr_case_id(explicit_case_id)
             elif case_path:
-                case_id = _norm_case_path(case_path)
+                case_id = normalize_cbr_case_id(case_path)
             else:
                 # Fallback: Generate unique case ID
                 content_str = f"{case.get('problem_context', '')}_{case.get('solution', '')}"

--- a/src/mind_swarm/subspace/coordinator.py
+++ b/src/mind_swarm/subspace/coordinator.py
@@ -1025,7 +1025,9 @@ class SubspaceCoordinator:
             for file_path in knowledge_dir.rglob("*"):
                 if file_path.suffix in [".yaml", ".yml", ".md", ".txt"]:
                     stats["total_files"] += 1
-                    relative_path = str(file_path.relative_to(knowledge_dir))
+                    relative_path = file_path.relative_to(knowledge_dir).as_posix()
+                    from mind_swarm.utils.id_policy import normalize_knowledge_id
+                    knowledge_id = normalize_knowledge_id("templates", relative_path)
                     
                     try:
                         with open(file_path, 'r', encoding='utf-8') as f:
@@ -1095,13 +1097,13 @@ class SubspaceCoordinator:
                         else:
                             full_content = content
                         
-                        # Try to get existing knowledge by path-based ID
-                        existing = await self.knowledge_handler.get_shared_knowledge(relative_path)
+                        # Try to get existing knowledge by normalized path-based ID
+                        existing = await self.knowledge_handler.get_shared_knowledge(knowledge_id)
                         
                         if existing:
                             # Update existing knowledge
                             success, message = await self.knowledge_handler.update_shared_knowledge(
-                                relative_path,  # Use path as ID
+                                knowledge_id,  # Use normalized, namespaced ID
                                 full_content, 
                                 metadata
                             )
@@ -1112,15 +1114,15 @@ class SubspaceCoordinator:
                                 stats["errors"] += 1
                                 logger.warning(f"Failed to update {relative_path}: {message}")
                         else:
-                            # Add new knowledge with path as ID
+                            # Add new knowledge with normalized, namespaced ID
                             success, knowledge_id = await self.knowledge_handler.add_shared_knowledge_with_id(
-                                knowledge_id=relative_path,  # Use path as ID
+                                knowledge_id=knowledge_id,  # Use normalized ID
                                 content=full_content, 
                                 metadata=metadata
                             )
                             if success:
                                 stats["added"] += 1
-                                logger.debug(f"Added {relative_path} with ID: {relative_path}")
+                                logger.debug(f"Added {relative_path} with ID: {knowledge_id}")
                             else:
                                 stats["errors"] += 1
                                 logger.warning(f"Failed to add {relative_path}: {knowledge_id}")

--- a/src/mind_swarm/subspace/coordinator.py
+++ b/src/mind_swarm/subspace/coordinator.py
@@ -1015,6 +1015,7 @@ class SubspaceCoordinator:
                 "added": 0,
                 "updated": 0,
                 "unchanged": 0,
+                "migrated": 0,
                 "errors": 0,
                 "total_files": 0
             }
@@ -1099,6 +1100,25 @@ class SubspaceCoordinator:
                         
                         # Try to get existing knowledge by normalized path-based ID
                         existing = await self.knowledge_handler.get_shared_knowledge(knowledge_id)
+
+                        # One-time migration: if old ID exists (relative_path) and new does not, migrate
+                        if not existing:
+                            existing_old = await self.knowledge_handler.get_shared_knowledge(relative_path)
+                            if existing_old:
+                                # Move old ID to new normalized ID using current file content/metadata
+                                success_mig, msg_mig = await self.knowledge_handler.add_shared_knowledge_with_id(
+                                    knowledge_id=knowledge_id,
+                                    content=full_content,
+                                    metadata=metadata,
+                                )
+                                if success_mig:
+                                    # Remove old entry
+                                    await self.knowledge_handler.remove_shared_knowledge(relative_path)
+                                    stats["migrated"] += 1
+                                    existing = {"id": knowledge_id}  # Treat as existing for update path
+                                    logger.debug(f"Migrated {relative_path} -> {knowledge_id}")
+                                else:
+                                    logger.warning(f"Failed to migrate {relative_path} -> {knowledge_id}: {msg_mig}")
                         
                         if existing:
                             # Update existing knowledge

--- a/src/mind_swarm/utils/id_policy.py
+++ b/src/mind_swarm/utils/id_policy.py
@@ -1,0 +1,68 @@
+"""ID normalization utilities for Knowledge and CBR.
+
+Applies deterministic, path-based normalization rules:
+- Lowercase
+- Trim and replace spaces with '-'
+- Remove leading slashes
+- Use forward slashes
+
+Knowledge IDs keep the provided relative path and file extensions, under a
+namespace such as 'templates/', 'library/sections/', etc.
+
+CBR case IDs normalize to 'cases/<...>' when a path-like value is provided.
+If a non-path explicit ID is provided (e.g., 'cbr_auto_...'), it is returned
+unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _normalize_path_segments(path_str: str) -> str:
+    """Normalize each segment: lowercase and replace spaces with hyphens.
+
+    Keeps dots as-is (useful for knowledge filenames with extensions).
+    Collapses empty segments caused by repeated slashes.
+    """
+    # Use POSIX separator to normalize across OSes
+    posix = Path(path_str.replace("\\", "/").lstrip("/")).as_posix()
+    parts = [p for p in posix.split("/") if p != ""]
+    norm_parts = ["-".join(seg.strip().split()).lower() for seg in parts]
+    return "/".join(norm_parts)
+
+
+def normalize_knowledge_id(namespace: str, rel_path: str) -> str:
+    """Normalize a knowledge ID under a namespace.
+
+    Example: normalize_knowledge_id("templates", "Guides/Onboarding.md")
+             -> "templates/guides/onboarding.md"
+    """
+    ns = _normalize_path_segments(namespace)
+    rel = _normalize_path_segments(rel_path)
+    if ns:
+        return f"{ns}/{rel}" if rel else ns
+    return rel
+
+
+def normalize_cbr_case_id(path_or_id: str) -> str:
+    """Normalize a CBR case identifier.
+
+    - If it looks path-like (contains '/'), coerce to cases/<...>.
+    - If it already starts with 'cases/', normalize after the prefix.
+    - Otherwise, return unchanged (explicit non-path IDs preserved).
+    """
+    raw = str(path_or_id or "").strip()
+    if not raw:
+        return raw
+    # If path-like or already namespaced
+    looks_path = "/" in raw or raw.startswith("cases/")
+    if looks_path:
+        stripped = raw.lstrip("/")
+        if stripped.startswith("cases/"):
+            inner = stripped[len("cases/") :]
+            return f"cases/{_normalize_path_segments(inner)}"
+        return f"cases/{_normalize_path_segments(stripped)}"
+    # Non-path explicit IDs: return as provided
+    return raw
+

--- a/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/constants.py
+++ b/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/constants.py
@@ -1,0 +1,31 @@
+"""Constants for the knowledge system."""
+
+# Default paths
+DEFAULT_PERSONAL_PATH = "/personal"
+DEFAULT_MEMORY_DIR_PATH = "/personal/.internal/memory"
+
+# Rate limiting
+MIN_REQUEST_INTERVAL = 0.1  # Minimum seconds between API requests
+
+# Search and filtering
+DEFAULT_MIN_SCORE = 0.35  # Minimum relevance score for knowledge results
+DEFAULT_SEARCH_LIMIT = 5  # Default number of search results
+MAX_SEARCH_LIMIT = 20  # Maximum allowed search results
+
+# Context building
+DEFAULT_BUDGET_CHARS = 1200  # Default character budget for knowledge context
+DEFAULT_QUERY_TRUNCATE_CHARS = 400  # Default truncation for query strings
+MAX_ACTIVE_TODOS = 5  # Maximum active todos to include in context
+
+# Timeouts
+DEFAULT_REQUEST_TIMEOUT = 30.0  # Default timeout for knowledge requests
+
+# File markers
+REQUEST_END_MARKER = "<<<END_KNOWLEDGE_REQUEST>>>"
+RESPONSE_COMPLETE_MARKER = "<<<KNOWLEDGE_COMPLETE>>>"
+
+# Confidence levels
+DEFAULT_CONFIDENCE = 0.8  # Default confidence for shared learnings
+
+# Polling
+RESPONSE_POLL_INTERVAL = 0.05  # Seconds between response checks

--- a/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/knowledge_context_builder.py
+++ b/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/knowledge_context_builder.py
@@ -10,21 +10,20 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 import json
-# NOTE: Base code runs inside the Cyber's sandbox and should not depend on
-# importing the server package. Read truncation limits from env with sane
-# defaults; if the server package is available, use it, but never require it.
-try:  # pragma: no cover - optional path only
-    from mind_swarm.core.config import KNOWLEDGE_QUERY_TRUNCATE_CHARS as _TRUNC
-except Exception:  # Fallback when mind_swarm is not importable in sandbox
-    import os
-    try:
-        _TRUNC = int(os.environ.get("KNOWLEDGE_QUERY_TRUNCATE_CHARS", "400"))
-    except Exception:
-        _TRUNC = 400
+import os
+from .constants import (
+    DEFAULT_MIN_SCORE,
+    DEFAULT_BUDGET_CHARS,
+    DEFAULT_QUERY_TRUNCATE_CHARS,
+    MAX_ACTIVE_TODOS
+)
 
-KNOWLEDGE_QUERY_TRUNCATE_CHARS = _TRUNC
+# Allow environment override for truncation
+KNOWLEDGE_QUERY_TRUNCATE_CHARS = int(
+    os.environ.get("KNOWLEDGE_QUERY_TRUNCATE_CHARS", DEFAULT_QUERY_TRUNCATE_CHARS)
+)
 
 
 logger = logging.getLogger("Cyber.knowledge.context_builder")
@@ -32,17 +31,25 @@ logger = logging.getLogger("Cyber.knowledge.context_builder")
 
 @dataclass
 class KnowledgeSnippet:
+    """Represents a single knowledge snippet with metadata."""
     id: str
     content: str
     score: float
     source: str
-    tags: str | None
+    tags: Optional[str]  # Tags are stored as comma-separated string in ChromaDB
 
 
 class KnowledgeContextBuilder:
     """Builds concise knowledge context strings for stage prompts."""
 
-    def __init__(self, knowledge_manager, memory_system, state_manager):
+    def __init__(self, knowledge_manager: Any, memory_system: Any, state_manager: Any) -> None:
+        """Initialize the context builder.
+        
+        Args:
+            knowledge_manager: Knowledge manager instance
+            memory_system: Memory system instance
+            state_manager: State manager instance
+        """
         self.knowledge_manager = knowledge_manager
         self.memory_system = memory_system
         self.state_manager = state_manager
@@ -53,9 +60,9 @@ class KnowledgeContextBuilder:
         queries: Sequence[str],
         *,
         limit: int = 3,
-        budget_chars: int = 1200,
+        budget_chars: int = DEFAULT_BUDGET_CHARS,
         blacklist_tags: Optional[Set[str]] = None,
-        min_score: float = 0.35,
+        min_score: float = DEFAULT_MIN_SCORE,
     ) -> str:
         """Search and format knowledge for a stage.
 
@@ -65,106 +72,182 @@ class KnowledgeContextBuilder:
         - Trims to a character budget for predictable token usage
         """
         blacklist_tags = blacklist_tags or set()
-
-        # Build a prioritized list of queries:
-        # 1) Current task summary/intention
-        # 2) Stage-provided queries (e.g., new_information, decision context)
-        # 3) Recent reflection
-        # 4) Current location (lowest priority)
+        
+        # Build prioritized query list
+        q = self._build_query_list(queries)
+        if not q:
+            return ""
+        
+        # Collect relevant knowledge snippets
+        collected = self._collect_knowledge_snippets(
+            q, limit, min_score, blacklist_tags
+        )
+        if not collected:
+            return ""
+        
+        # Order and format results
+        return self._format_knowledge_results(
+            collected, stage, budget_chars
+        )
+    
+    def _build_query_list(self, queries: Sequence[str]) -> List[str]:
+        """Build a prioritized list of queries."""
         q: List[str] = []
-
+        
+        # Priority 1: Current task context
         task_summary = self._current_task_summary()
         if task_summary:
             q.append(task_summary)
-
+        
         decision_intent = self._current_decision_intention()
         if decision_intent:
             q.append(decision_intent)
-
-        # Add current TODO/active task summaries (if any)
+        
         active_todos = self._active_task_summaries()
         if active_todos:
             q.append(active_todos)
-
+        
+        # Priority 2: Provided queries
         for s in queries:
             s = (s or "").strip()
             if s:
-                if KNOWLEDGE_QUERY_TRUNCATE_CHARS and KNOWLEDGE_QUERY_TRUNCATE_CHARS > 0:
-                    q.append(s[:KNOWLEDGE_QUERY_TRUNCATE_CHARS])  # basic guard
-                else:
-                    q.append(s)
-
+                q.append(self._truncate_query(s))
+        
+        # Priority 3: Historical context
         reflection = self._recent_reflection_summary()
         if reflection:
             q.append(reflection)
-
+        
+        # Priority 4: Location
         current_loc = self._current_location()
         if current_loc:
             q.append(str(current_loc))
-
-        if not q:
-            return ""
-
-        collected: dict[str, KnowledgeSnippet] = {}
-        for query in q:
+        
+        return q
+    
+    def _truncate_query(self, query: str) -> str:
+        """Truncate query string if needed."""
+        if KNOWLEDGE_QUERY_TRUNCATE_CHARS and KNOWLEDGE_QUERY_TRUNCATE_CHARS > 0:
+            return query[:KNOWLEDGE_QUERY_TRUNCATE_CHARS]
+        return query
+    
+    def _collect_knowledge_snippets(
+        self,
+        queries: List[str],
+        limit: int,
+        min_score: float,
+        blacklist_tags: Set[str]
+    ) -> Dict[str, KnowledgeSnippet]:
+        """Collect relevant knowledge snippets from searches."""
+        collected: Dict[str, KnowledgeSnippet] = {}
+        
+        for query in queries:
             try:
-                results = self.knowledge_manager.search_knowledge(query=query, limit=limit)
+                results = self.knowledge_manager.search_knowledge(
+                    query=query, limit=limit
+                )
             except Exception as e:
                 logger.debug(f"Knowledge search failed for '{query[:60]}...': {e}")
                 results = []
-
+            
             for item in results or []:
-                try:
-                    kid = str(item.get("id", ""))
-                    if not kid or kid in collected:
-                        continue
-                    score = float(item.get("score", 0.0))
-                    if score < min_score:
-                        continue
-                    tags = item.get("metadata", {}).get("tags")
-                    # tags are stored as comma-separated string
-                    if tags and any(t.strip() in blacklist_tags for t in str(tags).split(",")):
-                        continue
-                    content = str(item.get("content", "")).strip()
-                    if not content:
-                        continue
-                    collected[kid] = KnowledgeSnippet(
-                        id=kid,
-                        content=content,
-                        score=score,
-                        source=str(item.get("source", "shared")),
-                        tags=str(tags) if tags else None,
-                    )
-                except Exception:
-                    continue
-
-        if not collected:
-            return ""
-
+                snippet = self._process_search_result(
+                    item, min_score, blacklist_tags
+                )
+                if snippet and snippet.id not in collected:
+                    collected[snippet.id] = snippet
+        
+        return collected
+    
+    def _process_search_result(
+        self,
+        item: Dict[str, Any],
+        min_score: float,
+        blacklist_tags: Set[str]
+    ) -> Optional[KnowledgeSnippet]:
+        """Process a single search result into a snippet."""
+        try:
+            kid = str(item.get("id", ""))
+            if not kid:
+                return None
+            
+            score = float(item.get("score", 0.0))
+            if score < min_score:
+                return None
+            
+            # Check blacklisted tags
+            tags = item.get("metadata", {}).get("tags")
+            if tags and self._has_blacklisted_tag(tags, blacklist_tags):
+                return None
+            
+            content = str(item.get("content", "")).strip()
+            if not content:
+                return None
+            
+            return KnowledgeSnippet(
+                id=kid,
+                content=content,
+                score=score,
+                source=str(item.get("source", "shared")),
+                tags=str(tags) if tags else None,
+            )
+        except Exception:
+            return None
+    
+    def _has_blacklisted_tag(self, tags: Any, blacklist: Set[str]) -> bool:
+        """Check if tags contain any blacklisted tag."""
+        # Tags are stored as comma-separated string
+        tag_list = str(tags).split(",")
+        return any(t.strip() in blacklist for t in tag_list)
+    
+    def _format_knowledge_results(
+        self,
+        collected: Dict[str, KnowledgeSnippet],
+        stage: str,
+        budget_chars: int
+    ) -> str:
+        """Format collected knowledge snippets within budget."""
         # Order by score desc, prefer personal over shared when equal
         ordered = sorted(
             collected.values(),
             key=lambda s: (s.score, 1 if s.source == "shared" else 2),
             reverse=True,
         )
-
-        # Format with budget
+        
         lines: List[str] = [f"## Helpful Knowledge ({stage})"]
         used = 0
+        
         for i, snip in enumerate(ordered, 1):
-            header = f"\n{i}. [Relevance {snip.score:.2f}] ({snip.source})\n"
-            body_budget = max(0, budget_chars - used - len(header) - 32)
-            if body_budget <= 0:
+            formatted = self._format_snippet(snip, i, budget_chars - used)
+            if not formatted:
                 break
-            body = snip.content
-            if len(body) > body_budget:
-                body = body[: body_budget - 3] + "..."
-            lines.append(header + body)
-            used += len(header) + len(body)
+            
+            lines.append(formatted)
+            used += len(formatted)
+            
             if used >= budget_chars:
                 break
-
+        
         return "\n".join(lines).strip()
+    
+    def _format_snippet(
+        self,
+        snip: KnowledgeSnippet,
+        index: int,
+        remaining_budget: int
+    ) -> Optional[str]:
+        """Format a single knowledge snippet."""
+        header = f"\n{index}. [Relevance {snip.score:.2f}] ({snip.source})\n"
+        body_budget = remaining_budget - len(header) - 32
+        
+        if body_budget <= 0:
+            return None
+        
+        body = snip.content
+        if len(body) > body_budget:
+            body = body[: body_budget - 3] + "..."
+        
+        return header + body
 
     def _current_location(self) -> Optional[str]:
         try:
@@ -262,7 +345,7 @@ class KnowledgeContextBuilder:
                     title = str(data.get("title") or data.get("name") or data.get("summary") or "").strip()
                     if title:
                         items.append(title)
-                    if len(items) >= 5:
+                    if len(items) >= MAX_ACTIVE_TODOS:
                         break
                 except Exception:
                     continue

--- a/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/simplified_knowledge.py
+++ b/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/knowledge/simplified_knowledge.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Any
 
 # Import the existing Knowledge class from python_modules
 from ..python_modules.knowledge import Knowledge
+from .constants import DEFAULT_SEARCH_LIMIT, DEFAULT_PERSONAL_PATH, DEFAULT_MEMORY_DIR_PATH
 
 logger = logging.getLogger("Cyber.knowledge.simplified")
 
@@ -16,19 +17,28 @@ logger = logging.getLogger("Cyber.knowledge.simplified")
 class SimplifiedKnowledgeManager:
     """Manages knowledge access through the existing Knowledge API."""
     
-    def __init__(self):
-        """Initialize the simplified knowledge manager."""
-        # Create a dummy memory instance for Knowledge (it needs Memory for init)
-        # Knowledge needs _context attribute
-        class DummyMemory:
+    def __init__(self, memory_context=None):
+        """Initialize the simplified knowledge manager.
+        
+        Args:
+            memory_context: Optional memory context. If None, creates a minimal context.
+        """
+        if memory_context is None:
+            memory_context = self._create_minimal_context()
+        self.knowledge = Knowledge(memory_context)
+    
+    def _create_minimal_context(self):
+        """Create a minimal memory context for standalone usage."""
+        class MinimalMemoryContext:
+            """Minimal memory context for Knowledge API."""
             memory_api = None
             _context = {
                 "cyber_id": "unknown",
-                "personal": Path("/personal"),
-                "memory_dir": Path("/personal/.internal/memory")
+                "personal": Path(DEFAULT_PERSONAL_PATH),
+                "memory_dir": Path(DEFAULT_MEMORY_DIR_PATH)
             }
-            
-        self.knowledge = Knowledge(DummyMemory())
+        
+        return MinimalMemoryContext()
         
     def get_stage_instructions(self, stage_name: str) -> Optional[Dict[str, Any]]:
         """Fetch instructions for a specific cognitive stage.
@@ -71,7 +81,7 @@ class SimplifiedKnowledgeManager:
             logger.error(f"Knowledge search failed: {e}")
             return ""
 
-    def search_knowledge(self, query: str, limit: int = 5) -> list:
+    def search_knowledge(self, query: str, limit: int = DEFAULT_SEARCH_LIMIT) -> list:
         """Search the knowledge base.
         
         Args:

--- a/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/python_modules/knowledge.py
+++ b/subspace_template/grid/library/non-fiction/mind_swarm_tech/base_code/base_code_template/python_modules/knowledge.py
@@ -122,6 +122,12 @@ from pathlib import Path
 from typing import List, Dict, Optional, Any
 import logging
 
+from ..knowledge.constants import (
+    MIN_REQUEST_INTERVAL, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT,
+    DEFAULT_REQUEST_TIMEOUT, REQUEST_END_MARKER, RESPONSE_COMPLETE_MARKER,
+    DEFAULT_CONFIDENCE, RESPONSE_POLL_INTERVAL
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -141,10 +147,10 @@ class Knowledge:
         self.knowledge_file = Path("/personal/.internal/knowledge_api")
         self.request_counter = 0
         self._last_request_time = 0
-        self._min_request_interval = 0.1  # Minimum time between requests
+        self._min_request_interval = MIN_REQUEST_INTERVAL
         
-    def search(self, query: str, limit: int = 5, scope: Optional[List[str]] = None, 
-               timeout: float = 30.0) -> List[Dict[str, Any]]:
+    def search(self, query: str, limit: int = DEFAULT_SEARCH_LIMIT, scope: Optional[List[str]] = None, 
+               timeout: float = DEFAULT_REQUEST_TIMEOUT) -> List[Dict[str, Any]]:
         """
 Search for relevant knowledge.
 Args:
@@ -188,7 +194,7 @@ Returns:
             "operation": "search",
             "query": query,
             "options": {
-                "limit": min(limit, 20),  # Cap at 20
+                "limit": min(limit, MAX_SEARCH_LIMIT),
                 "scope": scope
             }
         }
@@ -205,7 +211,7 @@ Returns:
     
     def store(self, content: str, tags: Optional[List[str]] = None, 
               personal: bool = False, metadata: Optional[Dict[str, Any]] = None,
-              timeout: float = 30.0) -> Optional[str]:
+              timeout: float = DEFAULT_REQUEST_TIMEOUT) -> Optional[str]:
         """
         Store new knowledge.
         
@@ -253,7 +259,7 @@ Returns:
             logger.warning(f"Knowledge store failed: {error}")
             return None
     
-    def get(self, knowledge_id: str, timeout: float = 30.0) -> Optional[Dict[str, Any]]:
+    def get(self, knowledge_id: str, timeout: float = DEFAULT_REQUEST_TIMEOUT) -> Optional[Dict[str, Any]]:
         """
         Get knowledge by its ID.
         
@@ -300,7 +306,7 @@ Returns:
             logger.warning(f"Knowledge get failed: {error}")
             return None
     
-    def forget(self, knowledge_id: str, timeout: float = 30.0) -> bool:
+    def forget(self, knowledge_id: str, timeout: float = DEFAULT_REQUEST_TIMEOUT) -> bool:
         """
         Remove knowledge by ID.
         
@@ -336,7 +342,7 @@ Returns:
     
     def update(self, knowledge_id: str, content: Optional[str] = None, 
                tags: Optional[List[str]] = None, metadata: Optional[Dict[str, Any]] = None,
-               timeout: float = 30.0) -> bool:
+               timeout: float = DEFAULT_REQUEST_TIMEOUT) -> bool:
         """
         Update existing knowledge by ID. Any provided fields will overwrite existing ones.
         
@@ -436,7 +442,7 @@ Returns:
         return knowledge_text
     
     def share_learning(self, content: str, category: str = "experience", 
-                      confidence: float = 0.8) -> Optional[str]:
+                      confidence: float = DEFAULT_CONFIDENCE) -> Optional[str]:
         """
         Share a learning or insight with the hive mind.
         
@@ -506,61 +512,86 @@ Returns:
             Response dictionary or None if timeout
         """
         try:
-            # Clear any stale responses first (only if file exists)
-            if self.knowledge_file.exists():
-                current_content = self.knowledge_file.read_text()
-                if "<<<KNOWLEDGE_COMPLETE>>>" in current_content:
-                    logger.debug("Clearing stale knowledge response before new request")
-                    self.knowledge_file.write_text("")
+            # Clear any stale responses
+            self._clear_stale_responses()
             
-            # Write request with end marker
-            request_text = json.dumps(request, indent=2)
-            full_request = f"{request_text}\n<<<END_KNOWLEDGE_REQUEST>>>"
+            # Write request
+            full_request = self._format_request(request)
             self.knowledge_file.write_text(full_request)
             
-            # Wait for response with completion marker
-            start_time = time.time()
-            
-            while time.time() - start_time < timeout:
-                try:
-                    content = self.knowledge_file.read_text()
-                    
-                    # Check for completion marker
-                    if "<<<KNOWLEDGE_COMPLETE>>>" in content:
-                        # Extract response (everything before the marker)
-                        response_text = content.split("<<<KNOWLEDGE_COMPLETE>>>")[0].strip()
-                        
-                        # Parse the response
-                        response = json.loads(response_text)
-                        
-                        # Verify this is our response
-                        if response.get("request_id") == request["request_id"]:
-                            # Clear the file for next request
-                            self.knowledge_file.write_text("")
-                            return response
-                        else:
-                            # Wrong response (old or from another request)
-                            # Clear it and resend our request
-                            logger.warning(f"Got response for wrong request ID: {response.get('request_id')} != {request['request_id']}, resending")
-                            self.knowledge_file.write_text(full_request)
-                            # Continue waiting for our response
-                        
-                except json.JSONDecodeError:
-                    # Response might still be writing
-                    pass
-                except Exception as e:
-                    logger.error(f"Error reading knowledge response: {e}")
-                    
-                # Small delay before checking again
-                time.sleep(0.05)
-            
-            # Timeout reached - clear file
-            self.knowledge_file.write_text("")
-            logger.warning(f"Knowledge request timed out after {timeout}s")
-            return None
+            # Wait for and process response
+            return self._wait_for_response(request["request_id"], full_request, timeout)
             
         except Exception as e:
             logger.error(f"Error sending knowledge request: {e}")
+            return None
+    
+    def _clear_stale_responses(self):
+        """Clear any stale responses from the knowledge file."""
+        if self.knowledge_file.exists():
+            content = self.knowledge_file.read_text()
+            if RESPONSE_COMPLETE_MARKER in content:
+                logger.debug("Clearing stale knowledge response before new request")
+                self.knowledge_file.write_text("")
+    
+    def _format_request(self, request: Dict[str, Any]) -> str:
+        """Format request with end marker."""
+        request_text = json.dumps(request, indent=2)
+        return f"{request_text}\n{REQUEST_END_MARKER}"
+    
+    def _wait_for_response(
+        self, request_id: str, full_request: str, timeout: float
+    ) -> Optional[Dict[str, Any]]:
+        """Wait for response with completion marker."""
+        start_time = time.time()
+        
+        while time.time() - start_time < timeout:
+            response = self._check_for_response(request_id, full_request)
+            if response is not None:
+                return response
+            
+            # Small delay before checking again
+            time.sleep(RESPONSE_POLL_INTERVAL)
+        
+        # Timeout reached - clear file
+        self.knowledge_file.write_text("")
+        logger.warning(f"Knowledge request timed out after {timeout}s")
+        return None
+    
+    def _check_for_response(
+        self, request_id: str, full_request: str
+    ) -> Optional[Dict[str, Any]]:
+        """Check if a valid response is available."""
+        try:
+            content = self.knowledge_file.read_text()
+            
+            # Check for completion marker
+            if RESPONSE_COMPLETE_MARKER not in content:
+                return None
+            
+            # Extract and parse response
+            response_text = content.split(RESPONSE_COMPLETE_MARKER)[0].strip()
+            response = json.loads(response_text)
+            
+            # Verify this is our response
+            if response.get("request_id") == request_id:
+                # Clear the file for next request
+                self.knowledge_file.write_text("")
+                return response
+            else:
+                # Wrong response - resend request
+                logger.warning(
+                    f"Got response for wrong request ID: "
+                    f"{response.get('request_id')} != {request_id}, resending"
+                )
+                self.knowledge_file.write_text(full_request)
+                return None
+                
+        except json.JSONDecodeError:
+            # Response might still be writing
+            return None
+        except Exception as e:
+            logger.error(f"Error reading knowledge response: {e}")
             return None
     
     def __repr__(self) -> str:

--- a/test_knowledge_cbr.py
+++ b/test_knowledge_cbr.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 import sys
 import os
+from dotenv import load_dotenv
 
 # Add the src directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
@@ -15,8 +16,17 @@ from mind_swarm.subspace.cbr_handler import CBRHandler
 
 async def test_systems():
     """Test both knowledge and CBR systems."""
-    subspace_root = Path("/opt/mind-swarm/subspace")
-    subspace_root.mkdir(exist_ok=True)
+    # Load SUBSPACE_ROOT from .env if present, otherwise from environment
+    # Fall back to project-local ./subspace
+    try:
+        # Ensure .env values win in this test harness
+        load_dotenv(override=True)
+    except Exception:
+        pass
+
+    subspace_root_env = os.getenv("SUBSPACE_ROOT")
+    subspace_root = Path(os.path.expanduser(subspace_root_env)) if subspace_root_env else Path("./subspace")
+    subspace_root.mkdir(parents=True, exist_ok=True)
     
     print("=" * 50)
     print("Testing Knowledge and CBR Systems")

--- a/tests/test_id_policy.py
+++ b/tests/test_id_policy.py
@@ -1,0 +1,18 @@
+import pytest
+
+from mind_swarm.utils.id_policy import normalize_cbr_case_id, normalize_knowledge_id
+
+
+def test_normalize_cbr_case_id_path_like():
+    assert normalize_cbr_case_id("DevOps/Deploy/Rollout Strategy v1") == "cases/devops/deploy/rollout-strategy-v1"
+    assert normalize_cbr_case_id("/cases/ML/Model V2") == "cases/ml/model-v2"
+
+
+def test_normalize_cbr_case_id_non_path():
+    # Non-path explicit IDs are preserved
+    assert normalize_cbr_case_id("cbr_test_abc_123") == "cbr_test_abc_123"
+
+
+def test_normalize_knowledge_id_templates():
+    assert normalize_knowledge_id("templates", "Guides/Onboarding.md") == "templates/guides/onboarding.md"
+    assert normalize_knowledge_id("library/sections", "Python/AsyncIO.md") == "library/sections/python/asyncio.md"

--- a/tests/test_knowledge_sync_ids.py
+++ b/tests/test_knowledge_sync_ids.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from mind_swarm.subspace.coordinator import SubspaceCoordinator
+from mind_swarm.subspace.knowledge_handler import KnowledgeHandler
+
+
+@pytest.mark.asyncio
+async def test_sync_uses_templates_namespace(monkeypatch, tmp_path):
+    # Arrange: point subspace to a temporary, writable root
+    subspace_root = tmp_path / "subspace"
+    subspace_root.mkdir(parents=True, exist_ok=True)
+
+    # Monkeypatch coordinator init to be lightweight and avoid heavy subsystems
+    def fake_init(self, root_path: Path | None = None):
+        self.subspace = type("S", (), {"root_path": root_path})
+        self.knowledge_handler = KnowledgeHandler(root_path)
+        self.cbr_handler = None
+
+    monkeypatch.setattr(SubspaceCoordinator, "__init__", fake_init)
+
+    # Create a temporary knowledge file under the repo's template dir
+    repo_root = Path(__file__).resolve().parents[1]
+    initial_knowledge_dir = repo_root / "subspace_template" / "initial_knowledge" / "_sync_test"
+    initial_knowledge_dir.mkdir(parents=True, exist_ok=True)
+    test_file = initial_knowledge_dir / "Onboarding Guide.md"
+    test_file.write_text("# Onboarding Guide\n\nWelcome!", encoding="utf-8")
+
+    # Expected ID after sync
+    expected_id = "templates/_sync_test/onboarding-guide.md"
+
+    try:
+        # Act
+        coord = SubspaceCoordinator(subspace_root)
+        result = await coord.sync_knowledge()
+
+        # Assert: knowledge exists under normalized, namespaced ID
+        found = await coord.knowledge_handler.get_shared_knowledge(expected_id)
+        assert found is not None, f"Knowledge not found for ID: {expected_id}. Sync result: {result}"
+
+        # Cleanup from DB
+        await coord.knowledge_handler.remove_shared_knowledge(expected_id)
+    finally:
+        # Cleanup file artifact
+        try:
+            test_file.unlink(missing_ok=True)
+            # Remove folder if empty
+            if not any(initial_knowledge_dir.iterdir()):
+                initial_knowledge_dir.rmdir()
+        except Exception:
+            pass
+


### PR DESCRIPTION
Design and document a deterministic ID scheme using relative file paths.
- Knowledge IDs: e.g., templates/<rel_path>, library/sections/<rel_path>, community/<area>/<slug>, personal/<cyber>/<category>/<slug>.
- CBR: support optional path-based case IDs (cases/<domain>/<topic>/<slug>) via request.case_id and metadata.case_path; fallback to generated IDs.
- Deliverable: docs/knowledge_id_policy.md with examples and collision handling.

Milestone: M1 – Foundations
Depends on: Inventory (optional)
Blocks: config/knowledge_sync.yaml; Sync scopes; Export alignment; CBR path IDs; Body API explicit IDs