### PR TITLE
Add CLI: mind-swarm knowledge sync --scope (vibe-kanban)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1034,15 +1034,86 @@
     },
     "/knowledge/sync": {
       "post": {
-        "summary": "Sync Knowledge",
-        "description": "Sync knowledge from initial_knowledge templates to ChromaDB.",
-        "operationId": "sync_knowledge_knowledge_sync_post",
+        "summary": "Sync Knowledge Post",
+        "description": "Sync knowledge from configured sources to ChromaDB.\n\nArgs:\n    scope: Optional scope filter (library|template|community|all). Defaults to all.",
+        "operationId": "sync_knowledge_post_knowledge_sync_post",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Scope"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Sync Knowledge Get",
+        "description": "Sync knowledge from configured sources to ChromaDB.\n\nArgs:\n    scope: Optional scope filter (library|template|community|all). Defaults to all.",
+        "operationId": "sync_knowledge_get_knowledge_sync_get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Scope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }

--- a/src/mind_swarm/cli/commands/knowledge.py
+++ b/src/mind_swarm/cli/commands/knowledge.py
@@ -1,0 +1,110 @@
+"""Knowledge system CLI commands.
+
+Provides commands to interact with the server knowledge APIs.
+
+Example usage:
+  - Sync all knowledge sources:
+      mind-swarm knowledge sync
+  - Sync only library sources:
+      mind-swarm knowledge sync --scope library
+  - Sync template or community scopes:
+      mind-swarm knowledge sync --scope template
+      mind-swarm knowledge sync --scope community
+  - Explicitly sync all scopes:
+      mind-swarm knowledge sync --scope all
+"""
+
+import asyncio
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from mind_swarm.client import MindSwarmClient
+
+app = typer.Typer(help="Knowledge system commands")
+console = Console()
+
+
+@app.command("sync")
+def sync(
+    scope: Optional[str] = typer.Option(
+        None,
+        "--scope",
+        "-s",
+        help="Scope to sync: library | template | community | all (default: all)",
+        case_sensitive=False,
+        callback=lambda v: v.lower() if isinstance(v, str) else v,
+    )
+):
+    """Trigger a server-side knowledge sync and show a summary.
+
+    Contacts the server's /knowledge/sync endpoint with an optional scope
+    filter and displays counts for added, updated, unchanged, and errors.
+    """
+    valid_scopes = {"library", "template", "community", "all"}
+    if scope is not None and scope not in valid_scopes:
+        console.print(
+            f"[red]Invalid scope: {scope}. Valid options: library, template, community, all[/red]"
+        )
+        raise typer.Exit(code=2)
+
+    async def _run():
+        client = MindSwarmClient()
+        try:
+            # Perform sync; let server default handle None scope as "all"
+            result = await client.sync_knowledge(scope=scope)
+        except Exception as e:
+            console.print(
+                f"[red]Failed to contact server for knowledge sync: {e}[/red]"
+            )
+            console.print(
+                "[dim]Ensure the server is running: mind-swarm server start or ./run.sh server[/dim]"
+            )
+            raise typer.Exit(code=1)
+
+        status = result.get("status", "unknown")
+        message = result.get("message", "")
+
+        if status != "success":
+            console.print(f"[red]Sync failed: {message or 'Unknown error'}[/red]")
+            warnings = result.get("warnings") or []
+            for w in warnings:
+                console.print(f"[yellow]- {w}[/yellow]")
+            raise typer.Exit(code=1)
+
+        # Success output
+        config = result.get("config", {})
+        effective_scope = config.get("scope") or scope or "all"
+        roots = config.get("roots_processed", [])
+
+        console.print("[green]✓ Knowledge sync completed successfully[/green]")
+        if message:
+            console.print(f"[dim]{message}[/dim]")
+
+        # Summary table
+        stats = result.get("stats", {})
+        table = Table(title="Knowledge Sync Summary")
+        table.add_column("Metric", style="cyan")
+        table.add_column("Count", justify="right", style="green")
+        table.add_row("Added", str(stats.get("added", 0)))
+        table.add_row("Updated", str(stats.get("updated", 0)))
+        table.add_row("Unchanged", str(stats.get("unchanged", 0)))
+        table.add_row("Errors", str(stats.get("errors", 0)))
+        console.print(table)
+
+        # Details
+        console.print(
+            f"Scope: [bold]{effective_scope}[/bold]  •  Roots processed: {', '.join(roots) if roots else 'none'}"
+        )
+
+        # Show warnings if any
+        warnings = result.get("warnings") or []
+        if warnings:
+            console.print("\n[yellow]Warnings:[/yellow]")
+            for w in warnings:
+                console.print(f"  - {w}")
+
+    asyncio.run(_run())
+

--- a/src/mind_swarm/cli/main.py
+++ b/src/mind_swarm/cli/main.py
@@ -33,6 +33,10 @@ app.add_typer(models_app, name="models", help="Manage AI models")
 from mind_swarm.cli.commands.sync_openrouter import app as sync_openrouter_app
 app.add_typer(sync_openrouter_app, name="sync-openrouter", help="Sync models from OpenRouter API")
 
+# Import knowledge command group
+from mind_swarm.cli.commands.knowledge import app as knowledge_app
+app.add_typer(knowledge_app, name="knowledge", help="Knowledge system commands")
+
 
 class MindSwarmCLI:
     """Main CLI application class."""

--- a/src/mind_swarm/client/api.py
+++ b/src/mind_swarm/client/api.py
@@ -547,14 +547,18 @@ class MindSwarmClient:
             response.raise_for_status()
             return response.json()
     
-    async def sync_knowledge(self) -> Dict[str, Any]:
-        """Sync knowledge from initial_knowledge templates to ChromaDB.
+    async def sync_knowledge(self, scope: Optional[str] = None) -> Dict[str, Any]:
+        """Sync knowledge from configured sources to ChromaDB.
+        
+        Args:
+            scope: Optional scope filter (library|template|community|all). Defaults to all.
         
         Returns:
             Sync result with statistics
         """
         async with httpx.AsyncClient(timeout=httpx.Timeout(60.0)) as client:
-            response = await client.post(f"{self.base_url}/knowledge/sync")
+            params = {"scope": scope} if scope else {}
+            response = await client.post(f"{self.base_url}/knowledge/sync", params=params)
             response.raise_for_status()
             return response.json()
     

--- a/src/mind_swarm/server/api.py
+++ b/src/mind_swarm/server/api.py
@@ -872,13 +872,36 @@ class MindSwarmServer:
                 raise HTTPException(status_code=500, detail=str(e))
         
         @self.app.post("/knowledge/sync")
-        async def sync_knowledge():
-            """Sync knowledge from initial_knowledge templates to ChromaDB."""
+        async def sync_knowledge_post(scope: Optional[str] = None):
+            """Sync knowledge from configured sources to ChromaDB.
+            
+            Args:
+                scope: Optional scope filter (library|template|community|all). Defaults to all.
+            """
             if not self.coordinator:
                 raise HTTPException(status_code=503, detail="Server not initialized")
             
             try:
-                result = await self.coordinator.sync_knowledge()
+                result = await self.coordinator.sync_knowledge(scope=scope)
+                if result["status"] == "error":
+                    raise HTTPException(status_code=500, detail=result["message"])
+                return result
+            except Exception as e:
+                logger.error(f"Knowledge sync failed: {e}")
+                raise HTTPException(status_code=500, detail=str(e))
+        
+        @self.app.get("/knowledge/sync")
+        async def sync_knowledge_get(scope: Optional[str] = None):
+            """Sync knowledge from configured sources to ChromaDB.
+            
+            Args:
+                scope: Optional scope filter (library|template|community|all). Defaults to all.
+            """
+            if not self.coordinator:
+                raise HTTPException(status_code=503, detail="Server not initialized")
+            
+            try:
+                result = await self.coordinator.sync_knowledge(scope=scope)
                 if result["status"] == "error":
                     raise HTTPException(status_code=500, detail=result["message"])
                 return result

--- a/src/mind_swarm/subspace/coordinator.py
+++ b/src/mind_swarm/subspace/coordinator.py
@@ -990,7 +990,7 @@ class SubspaceCoordinator:
         except Exception as e:
             logger.error(f"Error loading default knowledge: {e}")
     
-    async def sync_knowledge(self) -> Dict[str, Any]:
+    async def sync_knowledge(self, scope: Optional[str] = None) -> Dict[str, Any]:
         """Sync knowledge from configured sources to ChromaDB.
         
         Uses knowledge_sync.yaml configuration to determine:
@@ -998,6 +998,11 @@ class SubspaceCoordinator:
         - How to namespace knowledge IDs
         - Which files to include/exclude
         - Security filters to apply
+        
+        Args:
+            scope: Optional scope filter to sync only specific roots.
+                   Options: 'library' (sections+schemas), 'template' (templates only),
+                           'community' (community only), 'all' or None (default, all enabled)
         
         Returns:
             Dictionary with sync statistics
@@ -1036,8 +1041,36 @@ class SubspaceCoordinator:
             # Get project root for resolving paths
             project_root = Path(__file__).parent.parent.parent.parent
             
-            # Process each enabled sync root
-            for root in config.get_enabled_roots():
+            # Filter roots based on scope parameter
+            roots_to_process = config.get_enabled_roots()
+            if scope and scope != 'all':
+                # Map scope to root names
+                scope_mapping = {
+                    'library': ['library_sections', 'library_schemas'],
+                    'template': ['templates'],
+                    'community': ['community']
+                }
+                
+                if scope not in scope_mapping:
+                    return {
+                        "status": "error",
+                        "message": f"Invalid scope '{scope}'. Valid options: library, template, community, all"
+                    }
+                
+                allowed_names = scope_mapping[scope]
+                roots_to_process = [r for r in roots_to_process if r.name in allowed_names]
+                
+                if not roots_to_process:
+                    return {
+                        "status": "warning",
+                        "message": f"No enabled roots found for scope '{scope}'",
+                        "stats": stats
+                    }
+                
+                logger.info(f"Applying scope filter '{scope}' - processing {len(roots_to_process)} root(s)")
+            
+            # Process each selected sync root
+            for root in roots_to_process:
                 logger.info(f"Processing sync root '{root.name}' (priority {root.priority})")
                 stats["roots_processed"].append(root.name)
                 
@@ -1121,8 +1154,8 @@ class SubspaceCoordinator:
                             "source_root": root.source_path,
                             "file_name": file_path.name,
                             "file_type": file_path.suffix[1:] if file_path.suffix else "txt",
-                            "source_path": relative_path.as_posix(),
-                            "synced_at": datetime.now().isoformat()
+                            "source_path": relative_path.as_posix()
+                            # Note: synced_at is added after content hash computation
                         })
                         
                         # Apply root-specific metadata
@@ -1184,10 +1217,18 @@ class SubspaceCoordinator:
                         else:
                             full_content = content
                         
-                        # Compute content hash if configured
+                        # Compute content hash if configured (before adding volatile fields)
                         if config.sync_behavior.get("use_content_hash", True):
-                            content_hash = compute_content_hash(full_content, metadata)
+                            # Create a copy of metadata without volatile fields for hash computation
+                            hash_metadata = metadata.copy()
+                            # Remove any volatile fields that would break idempotency
+                            hash_metadata.pop("synced_at", None)
+                            hash_metadata.pop("last_accessed", None)
+                            content_hash = compute_content_hash(full_content, hash_metadata)
                             metadata["content_hash"] = content_hash
+                        
+                        # Add timestamp after hash computation
+                        metadata["synced_at"] = datetime.now().isoformat()
                         
                         # Try to get existing knowledge by normalized ID
                         existing = await self.knowledge_handler.get_shared_knowledge(knowledge_id)
@@ -1212,18 +1253,30 @@ class SubspaceCoordinator:
                                     logger.warning(f"Failed to migrate {relative_path.as_posix()} -> {knowledge_id}: {msg_mig}")
                         
                         if existing:
-                            # Update existing knowledge
-                            success, message = await self.knowledge_handler.update_shared_knowledge(
-                                knowledge_id,  # Use normalized, namespaced ID
-                                full_content, 
-                                metadata
-                            )
-                            if success:
-                                stats["updated"] += 1
-                                logger.debug(f"Updated {relative_path}")
-                            else:
-                                stats["errors"] += 1
-                                logger.warning(f"Failed to update {relative_path}: {message}")
+                            # Check if content has changed (idempotency)
+                            needs_update = True
+                            if config.sync_behavior.get("use_content_hash", True) and "content_hash" in metadata:
+                                # Compare content hashes if available
+                                existing_metadata = existing.get("metadata", {})
+                                existing_hash = existing_metadata.get("content_hash")
+                                if existing_hash == metadata["content_hash"]:
+                                    needs_update = False
+                                    stats["unchanged"] += 1
+                                    logger.debug(f"Content unchanged (hash match) for {relative_path}")
+                            
+                            if needs_update:
+                                # Update existing knowledge
+                                success, message = await self.knowledge_handler.update_shared_knowledge(
+                                    knowledge_id,  # Use normalized, namespaced ID
+                                    full_content, 
+                                    metadata
+                                )
+                                if success:
+                                    stats["updated"] += 1
+                                    logger.debug(f"Updated {relative_path}")
+                                else:
+                                    stats["errors"] += 1
+                                    logger.warning(f"Failed to update {relative_path}: {message}")
                         else:
                             # Add new knowledge with normalized, namespaced ID
                             success, knowledge_id = await self.knowledge_handler.add_shared_knowledge_with_id(
@@ -1242,16 +1295,47 @@ class SubspaceCoordinator:
                         stats["errors"] += 1
                         logger.error(f"Error processing {file_path}: {e}")
             
+            # Calculate summary statistics
+            total_processed = stats["added"] + stats["updated"] + stats["unchanged"]
+            total_skipped = stats["skipped"] + stats["security_blocked"]
+            
+            # Add summary to stats
+            stats["summary"] = {
+                "total_files_scanned": stats["total_files"],
+                "total_processed": total_processed,
+                "total_skipped": total_skipped,
+                "success_rate": f"{(total_processed / stats['total_files'] * 100) if stats['total_files'] > 0 else 0:.1f}%",
+                "roots_count": len(stats["roots_processed"]),
+                "scope_applied": scope or "all"
+            }
+            
             # Log final statistics if configured
             if config.logging.get("log_statistics", True):
                 logger.info(f"Knowledge sync completed: {stats}")
             
-            return {
+            # Prepare detailed response
+            response = {
                 "status": "success",
-                "message": "Knowledge sync completed",
+                "message": f"Knowledge sync completed for scope: {scope or 'all'}",
                 "stats": stats,
-                "config_version": config.version
+                "config": {
+                    "version": config.version,
+                    "sync_behavior": config.sync_behavior,
+                    "scope": scope or "all",
+                    "roots_processed": stats["roots_processed"]
+                },
+                "timestamp": datetime.now().isoformat()
             }
+            
+            # Add warnings if any issues occurred
+            if stats["errors"] > 0:
+                response["warnings"] = [f"{stats['errors']} errors occurred during sync"]
+            if stats["security_blocked"] > 0:
+                if "warnings" not in response:
+                    response["warnings"] = []
+                response["warnings"].append(f"{stats['security_blocked']} files blocked by security filters")
+            
+            return response
             
         except Exception as e:
             logger.error(f"Knowledge sync failed: {e}")

--- a/test_sync_api.py
+++ b/test_sync_api.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Test the knowledge sync API with scope parameter."""
+
+import httpx
+import json
+import asyncio
+from typing import Optional
+
+API_BASE_URL = "http://localhost:8000"
+
+async def test_sync_endpoint(scope: Optional[str] = None):
+    """Test the sync endpoint with different scopes."""
+    
+    async with httpx.AsyncClient() as client:
+        # Build URL with scope parameter
+        url = f"{API_BASE_URL}/knowledge/sync"
+        params = {"scope": scope} if scope else {}
+        
+        print(f"\n--- Testing scope: {scope or 'default (all)'} ---")
+        
+        # Try GET request
+        print(f"Testing GET {url}")
+        try:
+            response = await client.get(url, params=params)
+            print(f"GET Status: {response.status_code}")
+            if response.status_code == 200:
+                data = response.json()
+                print_response(data)
+            else:
+                print(f"GET Error: {response.text}")
+        except Exception as e:
+            print(f"GET Exception: {e}")
+        
+        # Try POST request
+        print(f"\nTesting POST {url}")
+        try:
+            response = await client.post(url, params=params)
+            print(f"POST Status: {response.status_code}")
+            if response.status_code == 200:
+                data = response.json()
+                print_response(data)
+            else:
+                print(f"POST Error: {response.text}")
+        except Exception as e:
+            print(f"POST Exception: {e}")
+
+def print_response(data: dict):
+    """Pretty print the response data."""
+    
+    print(f"Status: {data.get('status', 'N/A')}")
+    print(f"Message: {data.get('message', 'N/A')}")
+    
+    if "config" in data:
+        config = data["config"]
+        print(f"Config Version: {config.get('version', 'N/A')}")
+        print(f"Scope Applied: {config.get('scope', 'N/A')}")
+        print(f"Roots Processed: {', '.join(config.get('roots_processed', []))}")
+    
+    if "stats" in data:
+        stats = data["stats"]
+        if "summary" in stats:
+            summary = stats["summary"]
+            print(f"\nSummary:")
+            print(f"  - Total Files Scanned: {summary.get('total_files_scanned', 0)}")
+            print(f"  - Total Processed: {summary.get('total_processed', 0)}")
+            print(f"  - Total Skipped: {summary.get('total_skipped', 0)}")
+            print(f"  - Success Rate: {summary.get('success_rate', '0%')}")
+            print(f"  - Roots Count: {summary.get('roots_count', 0)}")
+        
+        print(f"\nDetails:")
+        print(f"  - Added: {stats.get('added', 0)}")
+        print(f"  - Updated: {stats.get('updated', 0)}")
+        print(f"  - Unchanged: {stats.get('unchanged', 0)}")
+        print(f"  - Errors: {stats.get('errors', 0)}")
+        print(f"  - Security Blocked: {stats.get('security_blocked', 0)}")
+    
+    if "warnings" in data:
+        print(f"\nWarnings:")
+        for warning in data["warnings"]:
+            print(f"  - {warning}")
+
+async def main():
+    """Main test function."""
+    
+    print("="*60)
+    print("Testing Knowledge Sync API with Scopes")
+    print("="*60)
+    print(f"API URL: {API_BASE_URL}")
+    
+    # Check if server is running
+    async with httpx.AsyncClient() as client:
+        try:
+            response = await client.get(f"{API_BASE_URL}/health")
+            if response.status_code != 200:
+                print("\n⚠️  Server not available at", API_BASE_URL)
+                print("Please ensure the Mind-Swarm server is running:")
+                print("  ./run.sh server")
+                return
+        except Exception:
+            print("\n⚠️  Server not available at", API_BASE_URL)
+            print("Please ensure the Mind-Swarm server is running:")
+            print("  ./run.sh server")
+            return
+    
+    # Test different scopes
+    scopes = [None, 'all', 'library', 'template', 'community', 'invalid']
+    
+    for scope in scopes:
+        await test_sync_endpoint(scope)
+        print()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_sync_scope.py
+++ b/test_sync_scope.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Test the knowledge sync with scope parameter."""
+
+import asyncio
+import os
+from pathlib import Path
+import sys
+import json
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mind_swarm.subspace.coordinator import SubspaceCoordinator
+from mind_swarm.subspace.sandbox import SubspaceManager
+from mind_swarm.utils.logging import logger
+
+async def test_sync_with_scopes():
+    """Test knowledge sync with different scope values."""
+    
+    # Setup test environment
+    os.environ["SUBSPACE_ROOT"] = str(Path(__file__).parent / "test_subspace")
+    
+    # Create coordinator
+    subspace = SubspaceManager()
+    coordinator = SubspaceCoordinator(subspace)
+    
+    # Initialize if needed
+    if not coordinator.knowledge_handler or not coordinator.knowledge_handler.enabled:
+        logger.info("Knowledge system not available, initializing...")
+        await coordinator.initialize()
+    
+    print("\n" + "="*60)
+    print("Testing Knowledge Sync with Scopes")
+    print("="*60)
+    
+    # Test different scopes
+    scopes = ['template', 'library', 'community', 'all', None]
+    
+    for scope in scopes:
+        print(f"\n--- Testing scope: {scope or 'default (all)'} ---")
+        try:
+            result = await coordinator.sync_knowledge(scope=scope)
+            
+            if result["status"] == "success":
+                stats = result.get("stats", {})
+                config = result.get("config", {})
+                
+                print(f"Status: {result['status']}")
+                print(f"Message: {result['message']}")
+                print(f"Config Version: {config.get('version', 'N/A')}")
+                print(f"Scope Applied: {config.get('scope', 'N/A')}")
+                print(f"Roots Processed: {', '.join(config.get('roots_processed', []))}")
+                
+                if "summary" in stats:
+                    summary = stats["summary"]
+                    print(f"\nSummary:")
+                    print(f"  - Total Files Scanned: {summary.get('total_files_scanned', 0)}")
+                    print(f"  - Total Processed: {summary.get('total_processed', 0)}")
+                    print(f"  - Total Skipped: {summary.get('total_skipped', 0)}")
+                    print(f"  - Success Rate: {summary.get('success_rate', '0%')}")
+                    print(f"  - Roots Count: {summary.get('roots_count', 0)}")
+                
+                print(f"\nDetails:")
+                print(f"  - Added: {stats.get('added', 0)}")
+                print(f"  - Updated: {stats.get('updated', 0)}")
+                print(f"  - Unchanged: {stats.get('unchanged', 0)}")
+                print(f"  - Migrated: {stats.get('migrated', 0)}")
+                print(f"  - Errors: {stats.get('errors', 0)}")
+                print(f"  - Skipped: {stats.get('skipped', 0)}")
+                print(f"  - Security Blocked: {stats.get('security_blocked', 0)}")
+                
+                if "warnings" in result:
+                    print(f"\nWarnings:")
+                    for warning in result["warnings"]:
+                        print(f"  - {warning}")
+            else:
+                print(f"Error: {result.get('message', 'Unknown error')}")
+                
+        except Exception as e:
+            print(f"Exception: {e}")
+            import traceback
+            traceback.print_exc()
+    
+    # Test invalid scope
+    print(f"\n--- Testing invalid scope: 'invalid' ---")
+    try:
+        result = await coordinator.sync_knowledge(scope='invalid')
+        print(f"Status: {result['status']}")
+        print(f"Message: {result['message']}")
+    except Exception as e:
+        print(f"Exception: {e}")
+
+if __name__ == "__main__":
+    asyncio.run(test_sync_with_scopes())


### PR DESCRIPTION
Add CLI subcommand under src/mind_swarm/cli/commands/ to trigger server sync with scope.
- Command: `mind-swarm knowledge sync --scope [library|template|community|all]`
- Calls server /knowledge/sync; shows added/updated/unchanged/errors counts.
- Include help, examples, and error handling.

Milestone: M2 – Knowledge Sync
Depends on: Sync scopes endpoint
Blocks: Knowledge tests; Docs update